### PR TITLE
Add render abstraction for future Vulkan backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -270,6 +270,7 @@ target_sources(${EXECUTABLE_NAME} PUBLIC
     "src/pointer_registry.h"
     "src/plib/gnw/touch.cc"
     "src/plib/gnw/touch.h"
+    "src/render/render.cc"
 )
 
 if(IOS)

--- a/src/int/movie.cc
+++ b/src/int/movie.cc
@@ -18,6 +18,7 @@
 #include "plib/gnw/grbuf.h"
 #include "plib/gnw/input.h"
 #include "plib/gnw/svga.h"
+#include "render/render.h"
 #include "plib/gnw/text.h"
 #include "plib/gnw/winmain.h"
 
@@ -313,9 +314,10 @@ static void movie_MVE_ShowFrame(SDL_Surface* surface, int srcWidth, int srcHeigh
         }
     }
 
-    SDL_SetSurfacePalette(surface, gSdlSurface->format->palette);
-    SDL_BlitSurface(surface, &srcRect, gSdlSurface, &destRect);
-    SDL_BlitSurface(gSdlSurface, NULL, gSdlTextureSurface, NULL);
+    SDL_Surface* screenSurface = render_get_surface();
+    SDL_SetSurfacePalette(surface, screenSurface->format->palette);
+    SDL_BlitSurface(surface, &srcRect, screenSurface, &destRect);
+    SDL_BlitSurface(screenSurface, NULL, render_get_texture_surface(), NULL);
     renderPresent();
 }
 

--- a/src/plib/gnw/gnw.cc
+++ b/src/plib/gnw/gnw.cc
@@ -12,6 +12,7 @@
 #include "plib/gnw/intrface.h"
 #include "plib/gnw/memory.h"
 #include "plib/gnw/svga.h"
+#include "render/render.h"
 #include "plib/gnw/text.h"
 #include "plib/gnw/vcr.h"
 #include "plib/gnw/winmain.h"
@@ -111,8 +112,8 @@ int win_init(VideoOptions* video_options, int flags)
         return WINDOW_MANAGER_ERR_INITIALIZING_TEXT_FONTS;
     }
 
-    if (!svga_init(video_options)) {
-        svga_exit();
+    if (!render_init(RenderBackend::SDL, video_options)) {
+        render_exit();
 
         return WINDOW_MANAGER_ERR_INITIALIZING_VIDEO_MODE;
     }
@@ -120,7 +121,7 @@ int win_init(VideoOptions* video_options, int flags)
     if ((flags & 1) != 0) {
         screen_buffer = (unsigned char*)mem_malloc((scr_size.lry - scr_size.uly + 1) * (scr_size.lrx - scr_size.ulx + 1));
         if (screen_buffer == NULL) {
-            svga_exit();
+            render_exit();
 
             return WINDOW_MANAGER_ERR_NO_MEMORY;
         }
@@ -135,7 +136,7 @@ int win_init(VideoOptions* video_options, int flags)
     if (!initColors()) {
         unsigned char* palette = (unsigned char*)mem_malloc(768);
         if (palette == NULL) {
-            svga_exit();
+            render_exit();
 
             if (screen_buffer != NULL) {
                 mem_free(screen_buffer);
@@ -162,7 +163,7 @@ int win_init(VideoOptions* video_options, int flags)
 
     Window* w = window[0] = (Window*)mem_malloc(sizeof(*w));
     if (w == NULL) {
-        svga_exit();
+        render_exit();
 
         if (screen_buffer != NULL) {
             mem_free(screen_buffer);
@@ -230,7 +231,7 @@ void win_exit(void)
                 mem_free(screen_buffer);
             }
 
-            svga_exit();
+            render_exit();
 
             GNW_input_exit();
             GNW_rect_exit();
@@ -1269,9 +1270,7 @@ void win_set_minimized_title(const char* title)
     strncpy(GNW95_title, title, 256);
     GNW95_title[256 - 1] = '\0';
 
-    if (gSdlWindow != nullptr) {
-        SDL_SetWindowTitle(gSdlWindow, GNW95_title);
-    }
+    render_set_window_title(GNW95_title);
 }
 
 // 0x4C4204

--- a/src/plib/gnw/input.cc
+++ b/src/plib/gnw/input.cc
@@ -13,6 +13,7 @@
 #include "plib/gnw/intrface.h"
 #include "plib/gnw/memory.h"
 #include "plib/gnw/svga.h"
+#include "render/render.h"
 #include "plib/gnw/text.h"
 #include "plib/gnw/touch.h"
 #include "plib/gnw/vcr.h"
@@ -1118,7 +1119,7 @@ void GNW95_process_message()
                 win_refresh_all(&scr_size);
                 break;
             case SDL_WINDOWEVENT_SIZE_CHANGED:
-                handleWindowSizeChanged();
+                render_handle_window_size_changed();
                 win_refresh_all(&scr_size);
                 break;
             case SDL_WINDOWEVENT_FOCUS_GAINED:

--- a/src/render/render.cc
+++ b/src/render/render.cc
@@ -1,0 +1,59 @@
+#include "render/render.h"
+
+#include "plib/gnw/svga.h"
+
+namespace fallout {
+
+static RenderBackend gBackend = RenderBackend::SDL;
+
+bool render_init(RenderBackend backend, VideoOptions* options)
+{
+    gBackend = backend;
+
+    // Only SDL backend available for now
+    return svga_init(options);
+}
+
+void render_exit()
+{
+    svga_exit();
+}
+
+int render_get_width()
+{
+    return screenGetWidth();
+}
+
+int render_get_height()
+{
+    return screenGetHeight();
+}
+
+void render_handle_window_size_changed()
+{
+    handleWindowSizeChanged();
+}
+
+void render_present()
+{
+    renderPresent();
+}
+
+void render_set_window_title(const char* title)
+{
+    if (gSdlWindow != nullptr) {
+        SDL_SetWindowTitle(gSdlWindow, title);
+    }
+}
+
+SDL_Surface* render_get_surface()
+{
+    return gSdlSurface;
+}
+
+SDL_Surface* render_get_texture_surface()
+{
+    return gSdlTextureSurface;
+}
+
+} // namespace fallout

--- a/src/render/render.h
+++ b/src/render/render.h
@@ -1,0 +1,31 @@
+#ifndef FALLOUT_RENDER_RENDER_H_
+#define FALLOUT_RENDER_RENDER_H_
+
+#include <SDL.h>
+
+#include "plib/gnw/svga_types.h"
+
+namespace fallout {
+
+enum class RenderBackend {
+    SDL,
+    // Placeholder for Vulkan implementation
+};
+
+bool render_init(RenderBackend backend, VideoOptions* options);
+void render_exit();
+
+int render_get_width();
+int render_get_height();
+
+void render_handle_window_size_changed();
+void render_present();
+
+void render_set_window_title(const char* title);
+
+SDL_Surface* render_get_surface();
+SDL_Surface* render_get_texture_surface();
+
+} // namespace fallout
+
+#endif /* FALLOUT_RENDER_RENDER_H_ */


### PR DESCRIPTION
## Summary
- factorize renderer by introducing a generic API
- implement SDL backend behind new render API
- update build and source files to use the new abstraction

## Testing
- `cmake -S . -B build` *(fails: could not find SDL2)*