### PR TITLE
Enable user-selectable Vulkan backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,12 @@ The second configuration file is `f1_res.ini`. Use it to change game window size
 SCR_WIDTH=1280
 SCR_HEIGHT=720
 WINDOWED=1
+RENDER_BACKEND=SDL
 ```
+
+Use `RENDER_BACKEND=VULKAN` to enable the experimental Vulkan renderer. This
+setting can also be overridden by the `FALLOUT_RENDER_BACKEND` environment
+variable.
 
 Recommendations:
 - **Desktops**: Use any size you see fit.

--- a/src/int/window.cc
+++ b/src/int/window.cc
@@ -1527,7 +1527,7 @@ static void windowRemoveProgramReferences(Program* program)
 }
 
 // 0x4A5C9C
-void initWindow(VideoOptions* video_options, int flags)
+void initWindow(VideoOptions* video_options, int flags, RenderBackend backend)
 {
     char err[COMPAT_MAX_PATH];
     int rc;
@@ -1551,7 +1551,7 @@ void initWindow(VideoOptions* video_options, int flags)
         windows[i].window = -1;
     }
 
-    rc = win_init(video_options, flags);
+    rc = win_init(video_options, flags, backend);
     if (rc != WINDOW_MANAGER_OK) {
         switch (rc) {
         case WINDOW_MANAGER_ERR_INITIALIZING_VIDEO_MODE:

--- a/src/int/window.h
+++ b/src/int/window.h
@@ -7,6 +7,7 @@
 #include "plib/gnw/gnw.h"
 #include "plib/gnw/rect.h"
 #include "plib/gnw/svga_types.h"
+#include "render/render.h"
 
 namespace fallout {
 
@@ -87,7 +88,7 @@ int windowDisplayTransBuf(unsigned char* src, int srcWidth, int srcHeight, int d
 int windowDisplayBufScaled(unsigned char* src, int srcWidth, int srcHeight, int destX, int destY, int destWidth, int destHeight);
 int windowGetXres();
 int windowGetYres();
-void initWindow(VideoOptions* video_options, int flags);
+void initWindow(VideoOptions* video_options, int flags, RenderBackend backend);
 void windowSetWindowFuncs(ManagedWindowCreateCallback* createCallback, ManagedWindowSelectFunc* selectCallback, WindowDeleteCallback* deleteCallback, DisplayInWindowCallback* displayCallback);
 void windowClose();
 bool windowDeleteButton(const char* buttonName);

--- a/src/plib/gnw/gnw.cc
+++ b/src/plib/gnw/gnw.cc
@@ -77,7 +77,7 @@ static int doing_refresh_all;
 void* GNW_texture;
 
 // 0x4C1CF0
-int win_init(VideoOptions* video_options, int flags)
+int win_init(VideoOptions* video_options, int flags, RenderBackend backend)
 {
 #ifdef _WIN32
     CloseHandle(GNW95_mutex);
@@ -112,7 +112,7 @@ int win_init(VideoOptions* video_options, int flags)
         return WINDOW_MANAGER_ERR_INITIALIZING_TEXT_FONTS;
     }
 
-    if (!render_init(RenderBackend::SDL, video_options)) {
+    if (!render_init(backend, video_options)) {
         render_exit();
 
         return WINDOW_MANAGER_ERR_INITIALIZING_VIDEO_MODE;

--- a/src/plib/gnw/gnw.h
+++ b/src/plib/gnw/gnw.h
@@ -6,6 +6,7 @@
 #include "plib/gnw/gnw_types.h"
 #include "plib/gnw/rect.h"
 #include "plib/gnw/svga_types.h"
+#include "render/render.h"
 
 namespace fallout {
 
@@ -35,7 +36,7 @@ extern int GNW_wcolor[6];
 
 extern void* GNW_texture;
 
-int win_init(VideoOptions* video_options, int flags);
+int win_init(VideoOptions* video_options, int flags, RenderBackend backend);
 int win_active();
 void win_exit(void);
 int win_add(int x, int y, int width, int height, int color, int flags);


### PR DESCRIPTION
## Summary
- add runtime selection of rendering backend via `RENDER_BACKEND`
- plumb backend selection through window initialization
- document the new configuration option

## Testing
- `cmake -S . -B build` *(fails: could not download adecode dependency)*