### PR TITLE
Limit project to Windows x64

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -43,221 +43,11 @@ jobs:
       - name: clang-format
         run: find src -type f -name \*.cc -o -name \*.h | xargs clang-format --dry-run --Werror
 
-  android:
-    name: Android
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Clone
-        uses: actions/checkout@v4
-
-      - name: Setup Java
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 11
-          cache: gradle
-
-      - name: Cache cmake build
-        uses: actions/cache@v4
-        with:
-          path: os/android/app/.cxx
-          key: android-cmake-v1
-
-      - name: Setup signing config
-        if: env.KEYSTORE_FILE_BASE64 != '' && env.KEYSTORE_PROPERTIES_FILE_BASE64 != ''
-        run: |
-          cd os/android
-          echo "$KEYSTORE_FILE_BASE64" | base64 --decode > debug.keystore
-          echo "$KEYSTORE_PROPERTIES_FILE_BASE64" | base64 --decode > debug-keystore.properties
-        env:
-          KEYSTORE_FILE_BASE64: ${{ secrets.ANDROID_DEBUG_KEYSTORE_FILE_BASE64 }}
-          KEYSTORE_PROPERTIES_FILE_BASE64: ${{ secrets.ANDROID_DEBUG_KEYSTORE_PROPERTIES_FILE_BASE64 }}
-
-      - name: Build
-        run: |
-          cd os/android
-          ./gradlew assembleDebug
-
-      - name: Upload
-        uses: actions/upload-artifact@v4
-        with:
-          name: fallout-ce-debug.apk
-          path: os/android/app/build/outputs/apk/debug/app-debug.apk
-          retention-days: 7
-
-  ios:
-    name: iOS
-
-    runs-on: macos-13
-
-    steps:
-      - name: Clone
-        uses: actions/checkout@v4
-
-      - name: Cache cmake build
-        uses: actions/cache@v4
-        with:
-          path: build
-          key: ios-cmake-v2
-
-      - name: Configure
-        run: |
-          cmake \
-            -B build \
-            -D CMAKE_BUILD_TYPE=RelWithDebInfo \
-            -D CMAKE_TOOLCHAIN_FILE=cmake/toolchain/ios.toolchain.cmake \
-            -D ENABLE_BITCODE=0 \
-            -D PLATFORM=OS64 \
-            -G Xcode \
-            -D CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY='' \
-            # EOL
-
-      - name: Build
-        run: |
-          cmake \
-            --build build \
-            --config RelWithDebInfo \
-            -j $(sysctl -n hw.physicalcpu) \
-            # EOL
-
-      - name: Pack
-        run: |
-          cd build
-          cpack -C RelWithDebInfo
-
-      - name: Upload
-        uses: actions/upload-artifact@v4
-        with:
-          name: fallout-ce.ipa
-          path:  build/fallout-ce.ipa
-          retention-days: 7
-
-  linux:
-    name: Linux (${{ matrix.arch }})
-
-    runs-on: ubuntu-20.04
-
-    strategy:
-      fail-fast: false
-      matrix:
-        arch:
-          - x86
-          - x64
-
-    steps:
-      - name: Clone
-        uses: actions/checkout@v4
-
-      - name: Dependencies (x86)
-        if: matrix.arch == 'x86'
-        run: |
-          sudo dpkg --add-architecture i386
-          sudo apt update
-          sudo apt install --allow-downgrades libpcre2-8-0=10.34-7
-          sudo apt install g++-multilib libsdl2-dev:i386 zlib1g-dev:i386
-
-      - name: Dependencies (x64)
-        if: matrix.arch == 'x64'
-        run: |
-          sudo apt update
-          sudo apt install libsdl2-dev zlib1g-dev
-
-      - name: Cache cmake build
-        uses: actions/cache@v4
-        with:
-          path: build
-          key: linux-${{ matrix.arch }}-cmake-v1
-
-      - name: Configure (x86)
-        if: matrix.arch == 'x86'
-        run: |
-          cmake \
-            -B build \
-            -D CMAKE_BUILD_TYPE=RelWithDebInfo \
-            -D CMAKE_TOOLCHAIN_FILE=cmake/toolchain/Linux32.cmake \
-            # EOL
-
-      - name: Configure (x64)
-        if: matrix.arch == 'x64'
-        run: |
-          cmake \
-            -B build \
-            -D CMAKE_BUILD_TYPE=RelWithDebInfo \
-            # EOL
-
-      - name: Build
-        run: |
-          cmake \
-            --build build \
-            -j $(nproc) \
-            # EOL
-
-      - name: Upload
-        uses: actions/upload-artifact@v4
-        with:
-          name: fallout-ce-linux-${{ matrix.arch }}
-          path:  build/fallout-ce
-          retention-days: 7
-
-  macos:
-    name: macOS
-
-    runs-on: macos-13
-
-    steps:
-      - name: Clone
-        uses: actions/checkout@v4
-
-      - name: Cache cmake build
-        uses: actions/cache@v4
-        with:
-          path: build
-          key: macos-cmake-v4
-
-      - name: Configure
-        run: |
-          cmake \
-            -B build \
-            -G Xcode \
-            -D CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY='' \
-            # EOL
-
-      - name: Build
-        run: |
-          cmake \
-            --build build \
-            --config RelWithDebInfo \
-            -j $(sysctl -n hw.physicalcpu) \
-            # EOL
-
-      - name: Pack
-        run: |
-          cd build
-          cpack -C RelWithDebInfo
-
-      - name: Upload
-        uses: actions/upload-artifact@v4
-        with:
-          name: fallout-ce-macos.dmg
-          path:  build/Fallout Community Edition.dmg
-          retention-days: 7
-
   windows:
-    name: Windows (${{ matrix.arch }})
+    name: Windows x64
 
     runs-on: windows-2019
 
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - arch: x86
-            generator-platform: Win32
-          - arch: x64
-            generator-platform: x64
-
     steps:
       - name: Clone
         uses: actions/checkout@v4
@@ -266,14 +56,14 @@ jobs:
         uses: actions/cache@v4
         with:
           path: build
-          key: windows-${{ matrix.arch }}-cmake-v1
+          key: windows-x64-cmake-v1
 
       - name: Configure
         run: |
           cmake \
             -B build \
             -G "Visual Studio 16 2019" \
-            -A ${{ matrix.generator-platform }} \
+            -A x64 \
             # EOL
 
       - name: Build
@@ -286,6 +76,6 @@ jobs:
       - name: Upload
         uses: actions/upload-artifact@v4
         with:
-          name: fallout-ce-windows-${{ matrix.arch }}
-          path:  build/RelWithDebInfo/fallout-ce.exe
+          name: fallout-ce-windows-x64
+          path: build/RelWithDebInfo/fallout-ce.exe
           retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,254 +10,11 @@ defaults:
     shell: bash
 
 jobs:
-  android:
-    name: Android
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Clone
-        uses: actions/checkout@v4
-
-      - name: Setup Java
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 11
-          cache: gradle
-
-      - name: Cache cmake build
-        uses: actions/cache@v4
-        with:
-          path: os/android/app/.cxx
-          key: android-cmake-v1
-
-      - name: Setup signing config
-        if: env.KEYSTORE_FILE_BASE64 != '' && env.KEYSTORE_PROPERTIES_FILE_BASE64 != ''
-        run: |
-          cd os/android
-          echo "$KEYSTORE_FILE_BASE64" | base64 --decode > release.keystore
-          echo "$KEYSTORE_PROPERTIES_FILE_BASE64" | base64 --decode > release-keystore.properties
-        env:
-          KEYSTORE_FILE_BASE64: ${{ secrets.ANDROID_RELEASE_KEYSTORE_FILE_BASE64 }}
-          KEYSTORE_PROPERTIES_FILE_BASE64: ${{ secrets.ANDROID_RELEASE_KEYSTORE_PROPERTIES_FILE_BASE64 }}
-
-      - name: Build
-        run: |
-          cd os/android
-          ./gradlew assembleRelease
-
-      - name: Upload
-        run: |
-          cd os/android/app/build/outputs/apk/release
-          cp app-release.apk fallout-ce-android.apk
-          gh release upload ${{ github.event.release.tag_name }} fallout-ce-android.apk
-          rm fallout-ce-android.apk
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  ios:
-    name: iOS
-
-    runs-on: macos-12
-
-    steps:
-      - name: Clone
-        uses: actions/checkout@v4
-
-      - name: Cache cmake build
-        uses: actions/cache@v4
-        with:
-          path: build
-          key: ios-cmake-v1
-
-      - name: Configure
-        run: |
-          cmake \
-            -B build \
-            -D CMAKE_TOOLCHAIN_FILE=cmake/toolchain/ios.toolchain.cmake \
-            -D ENABLE_BITCODE=0 \
-            -D PLATFORM=OS64 \
-            -G Xcode \
-            -D CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY='' \
-            # EOL
-
-      - name: Build
-        run: |
-          cmake \
-            --build build \
-            --config RelWithDebInfo \
-            -j $(sysctl -n hw.physicalcpu) \
-            # EOL
-
-      - name: Pack
-        run: |
-          cd build
-          cpack -C RelWithDebInfo
-
-      - name: Upload
-        run: |
-          cd build
-          cp fallout-ce.ipa fallout-ce-ios.ipa
-          gh release upload ${{ github.event.release.tag_name }} fallout-ce-ios.ipa
-          rm fallout-ce-ios.ipa
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  linux:
-    name: Linux (${{ matrix.arch }})
-
-    runs-on: ubuntu-20.04
-
-    strategy:
-      fail-fast: false
-      matrix:
-        arch:
-          - x86
-          - x64
-
-    steps:
-      - name: Clone
-        uses: actions/checkout@v4
-
-      - name: Dependencies (x86)
-        if: matrix.arch == 'x86'
-        run: |
-          sudo dpkg --add-architecture i386
-          sudo apt update
-          sudo apt install --allow-downgrades libpcre2-8-0=10.34-7
-          sudo apt install g++-multilib libsdl2-dev:i386 zlib1g-dev:i386
-
-      - name: Dependencies (x64)
-        if: matrix.arch == 'x64'
-        run: |
-          sudo apt update
-          sudo apt install libsdl2-dev zlib1g-dev
-
-      - name: Cache cmake build
-        uses: actions/cache@v4
-        with:
-          path: build
-          key: linux-${{ matrix.arch }}-cmake-v1
-
-      - name: Configure (x86)
-        if: matrix.arch == 'x86'
-        run: |
-          cmake \
-            -B build \
-            -D CMAKE_BUILD_TYPE=RelWithDebInfo \
-            -D CMAKE_TOOLCHAIN_FILE=cmake/toolchain/Linux32.cmake \
-            # EOL
-
-      - name: Configure (x64)
-        if: matrix.arch == 'x64'
-        run: |
-          cmake \
-            -B build \
-            -D CMAKE_BUILD_TYPE=RelWithDebInfo \
-            # EOL
-
-      - name: Build
-        run: |
-          cmake \
-            --build build \
-            -j $(nproc) \
-            # EOL
-
-      - name: Upload
-        run: |
-          cd build
-          tar -czvf fallout-ce-linux-${{ matrix.arch }}.tar.gz fallout-ce
-          gh release upload ${{ github.event.release.tag_name }} fallout-ce-linux-${{ matrix.arch }}.tar.gz
-          rm fallout-ce-linux-${{ matrix.arch }}.tar.gz
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  macos:
-    name: macOS
-
-    runs-on: macos-11
-
-    steps:
-      - name: Clone
-        uses: actions/checkout@v4
-
-      - name: Import code signing certificates
-        uses: apple-actions/import-codesign-certs@v2
-        with:
-          p12-file-base64: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_P12_FILE_BASE64 }}
-          p12-password: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_P12_PASSWORD }}
-
-      - name: Cache cmake build
-        uses: actions/cache@v4
-        with:
-          path: build
-          key: macos-cmake-v3
-
-      - name: Configure
-        run: |
-          cmake \
-            -B build \
-            -G Xcode \
-            -D CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY="${{ secrets.APPLE_DEVELOPER_CERTIFICATE_IDENTITY }}" \
-            -D CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_INJECT_BASE_ENTITLEMENTS="NO" \
-            -D CMAKE_XCODE_ATTRIBUTE_OTHER_CODE_SIGN_FLAGS="--options=runtime --timestamp" \
-            # EOL
-
-      - name: Build
-        run: |
-          cmake \
-            --build build \
-            --config RelWithDebInfo \
-            -j $(sysctl -n hw.physicalcpu) \
-            # EOL
-
-      - name: Pack
-        run: |
-          cd build
-          cpack -C RelWithDebInfo
-
-      - name: Notarize
-        run: |
-          brew install mitchellh/gon/gon
-          cat << EOF > config.json
-          {
-            "notarize": {
-              "path": "build/Fallout Community Edition.dmg",
-              "bundle_id": "$(/usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" "build/RelWithDebInfo/Fallout Community Edition.app/Contents/Info.plist")",
-              "staple": true
-            }
-          }
-          EOF
-          gon config.json
-          rm config.json
-        env:
-          AC_USERNAME: ${{ secrets.APPLE_DEVELOPER_AC_USERNAME }}
-          AC_PASSWORD: ${{ secrets.APPLE_DEVELOPER_AC_PASSWORD }}
-
-      - name: Upload
-        run: |
-          cd build
-          cp "Fallout Community Edition.dmg" fallout-ce-macos.dmg
-          gh release upload ${{ github.event.release.tag_name }} fallout-ce-macos.dmg
-          rm fallout-ce-macos.dmg
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   windows:
-    name: Windows (${{ matrix.arch }})
+    name: Windows x64
 
     runs-on: windows-2019
 
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - arch: x86
-            generator-platform: Win32
-          - arch: x64
-            generator-platform: x64
-
     steps:
       - name: Clone
         uses: actions/checkout@v4
@@ -266,14 +23,14 @@ jobs:
         uses: actions/cache@v4
         with:
           path: build
-          key: windows-${{ matrix.arch }}-cmake-v1
+          key: windows-x64-cmake-v1
 
       - name: Configure
         run: |
           cmake \
             -B build \
             -G "Visual Studio 16 2019" \
-            -A ${{ matrix.generator-platform }} \
+            -A x64 \
             # EOL
 
       - name: Build
@@ -286,8 +43,8 @@ jobs:
       - name: Upload
         run: |
           cd build/RelWithDebInfo
-          7z a fallout-ce-windows-${{ matrix.arch }}.zip fallout-ce.exe
-          gh release upload ${{ github.event.release.tag_name }} fallout-ce-windows-${{ matrix.arch }}.zip
-          rm fallout-ce-windows-${{ matrix.arch }}.zip
+          7z a fallout-ce-windows-x64.zip fallout-ce.exe
+          gh release upload ${{ github.event.release.tag_name }} fallout-ce-windows-x64.zip
+          rm fallout-ce-windows-x64.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,28 +1,6 @@
 {
   "configurations": [
     {
-      "name": "x86-Debug",
-      "generator": "Visual Studio 16 2019",
-      "configurationType": "Debug",
-      "inheritEnvironments": [ "msvc_x86" ],
-      "buildRoot": "${projectDir}\\out\\build\\${name}",
-      "installRoot": "${projectDir}\\out\\install\\${name}",
-      "cmakeCommandArgs": "",
-      "buildCommandArgs": "",
-      "ctestCommandArgs": ""
-    },
-    {
-      "name": "x86-Release",
-      "generator": "Visual Studio 16 2019",
-      "configurationType": "Release",
-      "inheritEnvironments": [ "msvc_x86" ],
-      "buildRoot": "${projectDir}\\out\\build\\${name}",
-      "installRoot": "${projectDir}\\out\\install\\${name}",
-      "cmakeCommandArgs": "",
-      "buildCommandArgs": "",
-      "ctestCommandArgs": ""
-    },
-    {
       "name": "x64-Debug",
       "generator": "Visual Studio 16 2019 Win64",
       "configurationType": "Debug",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Fallout Community Edition
 
-Fallout Community Edition is a fully working re-implementation of Fallout, with the same original gameplay, engine bugfixes, and some quality of life improvements, that works (mostly) hassle-free on multiple platforms.
+Fallout Community Edition is a fully working re-implementation of Fallout, with the same original gameplay, engine bugfixes, and some quality of life improvements. This fork targets **64-bit Windows** only.
 
 There is also [Fallout 2 Community Edition](https://github.com/alexbatalov/fallout2-ce).
 
@@ -11,74 +11,6 @@ You must own the game to play. Purchase your copy on [GOG](https://www.gog.com/g
 ### Windows
 
 Download and copy `fallout-ce.exe` to your `Fallout` folder. It serves as a drop-in replacement for `falloutw.exe`.
-
-### Linux
-
-- Use Windows installation as a base - it contains data assets needed to play. Copy `Fallout` folder somewhere, for example `/home/john/Desktop/Fallout`.
-
-- Alternatively you can extract the needed files from the GoG installer:
-
-```console
-$ sudo apt install innoextract
-$ innoextract ~/Downloads/setup_fallout_2.1.0.18.exe -I app
-$ mv app Fallout
-```
-
-- Download and copy `fallout-ce` to this folder.
-
-- Install [SDL2](https://libsdl.org/download-2.0.php):
-
-```console
-$ sudo apt install libsdl2-2.0-0
-```
-
-- Run `./fallout-ce`.
-
-### macOS
-
-> **NOTE**: macOS 10.11 (El Capitan) or higher is required. Runs natively on Intel-based Macs and Apple Silicon.
-
-- Use Windows installation as a base - it contains data assets needed to play. Copy `Fallout` folder somewhere, for example `/Applications/Fallout`.
-
-- Alternatively you can use Fallout from MacPlay/The Omni Group as a base - you need to extract game assets from the original bundle. Mount CD/DMG, right click `Fallout` -> `Show Package Contents`, navigate to `Contents/Resources`. Copy `GameData` folder somewhere, for example `/Applications/Fallout`.
-
-- Or if you're a Terminal user and have Homebrew installed you can extract the needed files from the GoG installer:
-
-```console
-$ brew install innoextract
-$ innoextract ~/Downloads/setup_fallout_2.1.0.18.exe -I app
-$ mv app /Applications/Fallout
-```
-
-- Download and copy `fallout-ce.app` to this folder.
-
-- Run `fallout-ce.app`.
-
-### Android
-
-> **NOTE**: Fallout was designed with mouse in mind. There are many controls that require precise cursor positioning, which is not possible with fingers. Current control scheme resembles trackpad usage:
-> - One finger moves mouse cursor around.
-> - Tap one finger for left mouse click.
-> - Tap two fingers for right mouse click (switches mouse cursor mode).
-> - Move two fingers to scroll current view (map view, worldmap view, inventory scrollers).
-
-> **NOTE**: From Android standpoint release and debug builds are different apps. Both apps require their own copy of game assets and have their own savegames. This is intentional. As a gamer just stick with release version and check for updates.
-
-- Use Windows installation as a base - it contains data assets needed to play. Copy `Fallout` folder to your device, for example to `Downloads`. You need `master.dat`, `critter.dat`, and `data` folder. Watch for file names - keep (or make) them lowercased (see [Configuration](#configuration)).
-
-- Download `fallout-ce.apk` and copy it to your device. Open it with file explorer, follow instructions (install from unknown source).
-
-- When you run the game for the first time it will immediately present file picker. Select the folder from the first step. Wait until this data is copied. A loading dialog will appear, just wait for about 30 seconds. The game will start automatically.
-
-### iOS
-
-> **NOTE**: See Android note on controls.
-
-- Download `fallout-ce.ipa`. Use sideloading applications ([AltStore](https://altstore.io/) or [Sideloadly](https://sideloadly.io/)) to install it to your device. Alternatively you can always build from source with your own signing certificate.
-
-- Run the game once. You'll see error message saying "Could not find the master datafile...". This step is needed for iOS to expose the game via File Sharing feature.
-
-- Use Finder (macOS Catalina and later) or iTunes (Windows and macOS Mojave or earlier) to copy `master.dat`, `critter.dat`, and `data` folder to "Fallout" app ([how-to](https://support.apple.com/HT210598)). Watch for file names - keep (or make) them lowercased (see [Configuration](#configuration)).
 
 ## Configuration
 


### PR DESCRIPTION
## Summary
- adjust readme to mention Windows-only support and drop other OS instructions
- drop x86 configs from `CMakeSettings.json`
- simplify CI to only build Windows x64
- simplify release workflow to Windows x64 only

## Testing
- `git status --short`
