### PR TITLE
Embed default config and document env vars

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -16,11 +16,32 @@ Vous devez posséder le jeu pour y jouer. Achetez une copie sur [GOG](https://ww
 Téléchargez `fallout-ce.exe` et copiez-le dans votre dossier `Fallout`. Il remplace `falloutw.exe`.
 
 ## Configuration
-Le fichier principal de configuration est `fallout.cfg`. Plusieurs réglages importants peuvent nécessiter une adaptation pour votre installation. Selon votre distribution du jeu, les fichiers `master.dat`, `critter.dat` et le dossier `data` peuvent être en minuscules ou en majuscules. Vous pouvez soit mettre à jour les paramètres `master_dat`, `critter_dat`, `master_patches` et `critter_patches` pour correspondre à vos fichiers, soit renommer les fichiers afin qu'ils correspondent aux entrées du fichier.
+Le lanceur embarque désormais une configuration par défaut. Pour charger
+`fallout.cfg` ou `f1_res.ini`, définissez la variable d'environnement
+`F1CE_USE_CONFIG_FILES=1`.
 
-Le dossier `sound` (qui contient `music`) peut se trouver soit dans `data`, soit à la racine du jeu. Ajustez `music_path1` pour refléter votre organisation, par exemple `data/sound/music/` ou `sound/music/`. Les fichiers de musique (`ACM`) doivent être en majuscules, quel que soit l'emplacement du dossier `sound`.
+Il est aussi possible d'ajuster certaines options via variables
+d'environnement :
 
-Le second fichier de configuration est `f1_res.ini`. Utilisez-le pour changer la taille de la fenêtre de jeu et activer ou désactiver le plein écran.
+- `F1CE_WIDTH` et `F1CE_HEIGHT` — résolution souhaitée (min. 640×480).
+- `F1CE_WINDOWED` — mettre `1` pour jouer en fenêtre.
+- `F1CE_RENDER_BACKEND` — `SDL` ou `VULKAN`.
+
+Lorsque `F1CE_USE_CONFIG_FILES` est actif, le fichier principal reste
+`fallout.cfg`. Selon votre distribution du jeu, les fichiers `master.dat`,
+`critter.dat` et le dossier `data` peuvent être en minuscules ou en
+majuscules. Vous pouvez soit mettre à jour les paramètres `master_dat`,
+`critter_dat`, `master_patches` et `critter_patches` pour correspondre à vos
+fichiers, soit renommer les fichiers pour qu'ils correspondent aux entrées du
+fichier.
+
+Le dossier `sound` (qui contient `music`) peut se trouver soit dans `data`, soit
+à la racine du jeu. Ajustez `music_path1` en conséquence, par exemple
+`data/sound/music/` ou `sound/music/`. Les fichiers de musique (`ACM`) doivent
+être en majuscules, quel que soit l'emplacement du dossier `sound`.
+
+`f1_res.ini` permet de contrôler la taille de la fenêtre et le mode plein écran
+avec le format suivant :
 
 ```ini
 [MAIN]
@@ -35,7 +56,7 @@ Utilisez `RENDER_BACKEND=VULKAN` pour activer le rendu Vulkan expérimental. Ce 
 Recommandations :
 - **Ordinateurs de bureau** : utilisez la taille que vous souhaitez.
 
-Cette configuration disposera d'une interface intégrée ultérieurement. Pour l'instant elle doit être réalisée manuellement.
+Ces variables permettent de personnaliser sans modifier les fichiers de configuration.
 
 ## Contribuer
 Voici quelques objectifs actuels. Ouvrez une issue si vous avez des suggestions ou des demandes de fonctionnalités.

--- a/README.md
+++ b/README.md
@@ -21,11 +21,30 @@ Download and copy `fallout-ce.exe` to your `Fallout` folder. It serves as a drop
 
 ## Configuration
 
-The main configuration file is `fallout.cfg`. There are several important settings you might need to adjust for your installation. Depending on your Fallout distribution main game assets `master.dat`, `critter.dat`, and `data` folder might be either all lowercased, or all uppercased. You can either update `master_dat`, `critter_dat`, `master_patches` and `critter_patches` settings to match your file names, or rename files to match entries in your `fallout.cfg`.
+The launcher contains default configuration so the game works out of the box. If
+you want to load `fallout.cfg` or `f1_res.ini` anyway, set the environment
+variable `F1CE_USE_CONFIG_FILES=1`.
 
-The `sound` folder (with `music` folder inside) might be located either in `data` folder, or be in the Fallout folder. Update `music_path1` setting to match your hierarchy, usually it's `data/sound/music/` or `sound/music/`. Make sure it match your path exactly (so it might be `SOUND/MUSIC/` if you've installed Fallout from CD). Music files themselves (with `ACM` extension) should be all uppercased, regardless of `sound` and `music` folders.
+You can also tweak a few options via environment variables:
 
-The second configuration file is `f1_res.ini`. Use it to change game window size and enable/disable fullscreen mode.
+- `F1CE_WIDTH` and `F1CE_HEIGHT` – desired resolution (minimum 640×480).
+- `F1CE_WINDOWED` – set to `1` for windowed mode.
+- `F1CE_RENDER_BACKEND` – `SDL` or `VULKAN`.
+
+When `F1CE_USE_CONFIG_FILES` is enabled the main configuration file is
+`fallout.cfg`. Depending on your Fallout distribution main game assets
+`master.dat`, `critter.dat`, and `data` folder might be either all lowercased or
+all uppercased. You can either update `master_dat`, `critter_dat`,
+`master_patches` and `critter_patches` settings to match your file names, or
+rename files to match entries in your `fallout.cfg`.
+
+The `sound` folder (with `music` folder inside) might be located either in `data`
+folder, or be in the Fallout folder. Update `music_path1` accordingly, usually
+it's `data/sound/music/` or `sound/music/`. Music files themselves (with `ACM`
+extension) should be all uppercased, regardless of `sound` and `music` folders.
+
+`f1_res.ini` controls window size and fullscreen mode and supports the following
+format:
 
 ```ini
 [MAIN]
@@ -42,7 +61,7 @@ variable.
 Recommendations:
 - **Desktops**: Use any size you see fit.
 
-In time this stuff will receive in-game interface, right now you have to do it manually.
+These variables allow simple tweaks without editing configuration files.
 
 ## Contributing
 

--- a/src/game/game.cc
+++ b/src/game/game.cc
@@ -152,8 +152,11 @@ int game_init(const char* windowTitle, bool isMapper, int font, int flags, int a
 
     RenderBackend backend = RenderBackend::SDL;
 
+    const char* use_config = getenv("F1CE_USE_CONFIG_FILES");
+    bool load_res = use_config != NULL && strcmp(use_config, "1") == 0;
+
     Config resolutionConfig;
-    if (config_init(&resolutionConfig)) {
+    if (load_res && config_init(&resolutionConfig)) {
         if (config_load(&resolutionConfig, "f1_res.ini", false)) {
             int screenWidth;
             if (config_get_value(&resolutionConfig, "MAIN", "SCR_WIDTH", &screenWidth)) {
@@ -185,6 +188,26 @@ int game_init(const char* windowTitle, bool isMapper, int font, int flags, int a
             }
         }
         config_exit(&resolutionConfig);
+    }
+
+    const char* envWidth = getenv("F1CE_WIDTH");
+    if (envWidth != nullptr) {
+        video_options.width = std::max(atoi(envWidth), 640);
+    }
+
+    const char* envHeight = getenv("F1CE_HEIGHT");
+    if (envHeight != nullptr) {
+        video_options.height = std::max(atoi(envHeight), 480);
+    }
+
+    const char* envWindowed = getenv("F1CE_WINDOWED");
+    if (envWindowed != nullptr) {
+        video_options.fullscreen = strcmp(envWindowed, "1") != 0;
+    }
+
+    const char* envBackend2 = getenv("F1CE_RENDER_BACKEND");
+    if (envBackend2 != nullptr && compat_stricmp(envBackend2, "VULKAN") == 0) {
+        backend = RenderBackend::VULKAN;
     }
 
     const char* envBackend = getenv("FALLOUT_RENDER_BACKEND");

--- a/src/game/gconfig.cc
+++ b/src/game/gconfig.cc
@@ -2,6 +2,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 
 #include "platform_compat.h"
 
@@ -129,9 +130,13 @@ bool gconfig_init(bool isMapper, int argc, char** argv)
         strcpy(gconfig_file_name, GAME_CONFIG_FILE_NAME);
     }
 
-    // Read contents of `fallout.cfg` into config. The values from the file
-    // will override the defaults above.
-    config_load(&game_config, gconfig_file_name, false);
+    // Optionally load `fallout.cfg` if configuration files are enabled.
+    const char* use_config = getenv("F1CE_USE_CONFIG_FILES");
+    if (use_config != NULL && strcmp(use_config, "1") == 0) {
+        // Read contents of `fallout.cfg` into config. The values from the file
+        // will override the defaults above.
+        config_load(&game_config, gconfig_file_name, false);
+    }
 
     // Add key-values from command line, which overrides both defaults and
     // whatever was loaded from `fallout.cfg`.
@@ -151,8 +156,11 @@ bool gconfig_save()
         return false;
     }
 
-    if (!config_save(&game_config, gconfig_file_name, false)) {
-        return false;
+    const char* use_config = getenv("F1CE_USE_CONFIG_FILES");
+    if (use_config != NULL && strcmp(use_config, "1") == 0) {
+        if (!config_save(&game_config, gconfig_file_name, false)) {
+            return false;
+        }
     }
 
     return true;
@@ -170,8 +178,11 @@ bool gconfig_exit(bool shouldSave)
     bool result = true;
 
     if (shouldSave) {
-        if (!config_save(&game_config, gconfig_file_name, false)) {
-            result = false;
+        const char* use_config = getenv("F1CE_USE_CONFIG_FILES");
+        if (use_config != NULL && strcmp(use_config, "1") == 0) {
+            if (!config_save(&game_config, gconfig_file_name, false)) {
+                result = false;
+            }
         }
     }
 

--- a/src/plib/gnw/winmain.cc
+++ b/src/plib/gnw/winmain.cc
@@ -34,6 +34,10 @@ char GNW95_title[256];
 static void show_render_backend_launcher()
 {
 #if !defined(__ANDROID__) && !(defined(__APPLE__) && TARGET_OS_IOS)
+    const char* use_config = getenv("F1CE_USE_CONFIG_FILES");
+    if (use_config == NULL || strcmp(use_config, "1") != 0) {
+        return;
+    }
     Config config;
     if (!config_init(&config)) {
         return;


### PR DESCRIPTION
## Summary
- integrate config loading with optional env var `F1CE_USE_CONFIG_FILES`
- allow overriding video and backend options via environment variables
- skip config interaction when not using config files
- update README files to document new behaviour

## Testing
- `cmake -S . -B build` *(fails: Could not find SDL2 configuration)*