### PR TITLE
Add Vulkan advanced graphics configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,6 +179,8 @@ target_sources(${EXECUTABLE_NAME} PUBLIC
     "src/game/worldmap_walkmask.h"
     "src/game/worldmap.cc"
     "src/game/worldmap.h"
+    "src/game/graphics_advanced.cc"
+    "src/game/graphics_advanced.h"
     "src/int/audio.cc"
     "src/int/audio.h"
     "src/int/audiof.cc"

--- a/src/fps_limiter.cc
+++ b/src/fps_limiter.cc
@@ -22,4 +22,9 @@ void FpsLimiter::throttle() const
     }
 }
 
+void FpsLimiter::setFps(unsigned int fps)
+{
+    _fps = fps;
+}
+
 } // namespace fallout

--- a/src/fps_limiter.h
+++ b/src/fps_limiter.h
@@ -8,9 +8,10 @@ public:
     FpsLimiter(unsigned int fps = 60);
     void mark();
     void throttle() const;
+    void setFps(unsigned int fps);
 
 private:
-    const unsigned int _fps;
+    unsigned int _fps;
     unsigned int _ticks;
 };
 

--- a/src/game/game.cc
+++ b/src/game/game.cc
@@ -18,6 +18,7 @@
 #include "game/fontmgr.h"
 #include "game/gconfig.h"
 #include "game/gdialog.h"
+#include "game/graphics_advanced.h"
 #include "game/gmemory.h"
 #include "game/gmouse.h"
 #include "game/gmovie.h"
@@ -205,8 +206,14 @@ int game_init(const char* windowTitle, bool isMapper, int font, int flags, int a
                     backend = RenderBackend::VULKAN;
                 }
             }
+
+            graphics_advanced_load();
+            graphics_advanced_apply();
         }
         config_exit(&resolutionConfig);
+    } else {
+        graphics_advanced_load();
+        graphics_advanced_apply();
     }
 
     const char* envWidth = getenv("F1CE_WIDTH");

--- a/src/game/graphics_advanced.cc
+++ b/src/game/graphics_advanced.cc
@@ -1,0 +1,149 @@
+#include "game/graphics_advanced.h"
+
+#include <SDL.h>
+#include <vulkan/vulkan.h>
+#include <vector>
+#include <string>
+#include <stdlib.h>
+#include <string.h>
+
+#include "game/config.h"
+#include "platform_compat.h"
+#include "plib/gnw/intrface.h"
+#include "plib/gnw/svga.h"
+
+namespace fallout {
+
+GraphicsAdvancedOptions gGraphicsAdvanced{0, 2, 1, true, 60, false};
+
+static std::vector<std::string> enumerate_gpus()
+{
+    std::vector<std::string> names;
+    if (SDL_Vulkan_LoadLibrary(nullptr) != 0)
+        return names;
+
+    VkApplicationInfo appInfo{VK_STRUCTURE_TYPE_APPLICATION_INFO};
+    appInfo.apiVersion = VK_API_VERSION_1_0;
+
+    VkInstanceCreateInfo instInfo{VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO};
+    instInfo.pApplicationInfo = &appInfo;
+
+    VkInstance instance = VK_NULL_HANDLE;
+    if (vkCreateInstance(&instInfo, nullptr, &instance) != VK_SUCCESS) {
+        SDL_Vulkan_UnloadLibrary();
+        return names;
+    }
+
+    uint32_t count = 0;
+    vkEnumeratePhysicalDevices(instance, &count, nullptr);
+    if (count > 0) {
+        std::vector<VkPhysicalDevice> devices(count);
+        vkEnumeratePhysicalDevices(instance, &count, devices.data());
+        names.reserve(count);
+        for (uint32_t i = 0; i < count; i++) {
+            VkPhysicalDeviceProperties props;
+            vkGetPhysicalDeviceProperties(devices[i], &props);
+            names.emplace_back(props.deviceName);
+        }
+    }
+
+    vkDestroyInstance(instance, nullptr);
+    SDL_Vulkan_UnloadLibrary();
+    return names;
+}
+
+void graphics_advanced_load()
+{
+    const char* use_config = getenv("F1CE_USE_CONFIG_FILES");
+    if (use_config == NULL || strcmp(use_config, "1") != 0)
+        return;
+
+    Config cfg;
+    if (!config_init(&cfg))
+        return;
+
+    if (config_load(&cfg, "f1_res.ini", false)) {
+        config_get_value(&cfg, "MAIN", "GPU_INDEX", &gGraphicsAdvanced.gpuIndex);
+        config_get_value(&cfg, "MAIN", "TEXTURE_QUALITY", &gGraphicsAdvanced.textureQuality);
+        config_get_value(&cfg, "MAIN", "FILTERING", &gGraphicsAdvanced.filtering);
+        configGetBool(&cfg, "MAIN", "VSYNC", &gGraphicsAdvanced.vsync);
+        config_get_value(&cfg, "MAIN", "FPS_LIMIT", &gGraphicsAdvanced.fpsLimit);
+        configGetBool(&cfg, "MAIN", "VK_VALIDATION", &gGraphicsAdvanced.validation);
+    }
+
+    config_exit(&cfg);
+}
+
+void graphics_advanced_save()
+{
+    const char* use_config = getenv("F1CE_USE_CONFIG_FILES");
+    if (use_config == NULL || strcmp(use_config, "1") != 0)
+        return;
+
+    Config cfg;
+    if (!config_init(&cfg))
+        return;
+
+    config_load(&cfg, "f1_res.ini", false);
+    config_set_value(&cfg, "MAIN", "GPU_INDEX", gGraphicsAdvanced.gpuIndex);
+    config_set_value(&cfg, "MAIN", "TEXTURE_QUALITY", gGraphicsAdvanced.textureQuality);
+    config_set_value(&cfg, "MAIN", "FILTERING", gGraphicsAdvanced.filtering);
+    configSetBool(&cfg, "MAIN", "VSYNC", gGraphicsAdvanced.vsync);
+    config_set_value(&cfg, "MAIN", "FPS_LIMIT", gGraphicsAdvanced.fpsLimit);
+    configSetBool(&cfg, "MAIN", "VK_VALIDATION", gGraphicsAdvanced.validation);
+    config_save(&cfg, "f1_res.ini", false);
+    config_exit(&cfg);
+}
+
+void graphics_advanced_apply()
+{
+    sharedFpsLimiter.setFps(gGraphicsAdvanced.fpsLimit);
+}
+
+int do_graphics_advanced()
+{
+    std::vector<std::string> gpus = enumerate_gpus();
+    std::vector<char*> gpuList;
+    for (const auto& n : gpus) {
+        gpuList.push_back(const_cast<char*>(n.c_str()));
+    }
+    if (!gpuList.empty()) {
+        int idx = win_list_select("Select GPU", gpuList.data(), gpuList.size(), NULL, 80, 80, 0x10000 | 0x100 | 4);
+        if (idx != -1)
+            gGraphicsAdvanced.gpuIndex = idx;
+    }
+
+    char* qualityItems[] = { (char*)"Low", (char*)"Medium", (char*)"High" };
+    int q = win_list_select("Texture Quality", qualityItems, 3, NULL, 80, 80, 0x10000 | 0x100 | 4);
+    if (q != -1)
+        gGraphicsAdvanced.textureQuality = q;
+
+    char* filterItems[] = { (char*)"Nearest", (char*)"Linear" };
+    int f = win_list_select("Filtering", filterItems, 2, NULL, 80, 80, 0x10000 | 0x100 | 4);
+    if (f != -1)
+        gGraphicsAdvanced.filtering = f;
+
+    char* yesno[] = { (char*)"No", (char*)"Yes" };
+    int v = win_list_select("V-sync", yesno, 2, NULL, 80, 80, 0x10000 | 0x100 | 4);
+    if (v != -1)
+        gGraphicsAdvanced.vsync = v == 1;
+
+    char str[16];
+    snprintf(str, sizeof(str), "%d", gGraphicsAdvanced.fpsLimit);
+    if (win_get_str(str, sizeof(str), "FPS Limit", 80, 80) == 0) {
+        int val = atoi(str);
+        if (val > 0)
+            gGraphicsAdvanced.fpsLimit = val;
+    }
+
+    int d = win_list_select("Validation Layers", yesno, 2, NULL, 80, 80, 0x10000 | 0x100 | 4);
+    if (d != -1)
+        gGraphicsAdvanced.validation = d == 1;
+
+    graphics_advanced_save();
+    graphics_advanced_apply();
+    return 0;
+}
+
+} // namespace fallout
+

--- a/src/game/graphics_advanced.h
+++ b/src/game/graphics_advanced.h
@@ -1,0 +1,24 @@
+#ifndef FALLOUT_GAME_GRAPHICS_ADVANCED_H_
+#define FALLOUT_GAME_GRAPHICS_ADVANCED_H_
+
+namespace fallout {
+
+struct GraphicsAdvancedOptions {
+    int gpuIndex;
+    int textureQuality;
+    int filtering;
+    bool vsync;
+    int fpsLimit;
+    bool validation;
+};
+
+extern GraphicsAdvancedOptions gGraphicsAdvanced;
+
+void graphics_advanced_load();
+void graphics_advanced_save();
+void graphics_advanced_apply();
+int do_graphics_advanced();
+
+} // namespace fallout
+
+#endif /* FALLOUT_GAME_GRAPHICS_ADVANCED_H_ */

--- a/src/game/options.cc
+++ b/src/game/options.cc
@@ -13,6 +13,7 @@
 #include "game/game.h"
 #include "game/gconfig.h"
 #include "game/gmouse.h"
+#include "game/graphics_advanced.h"
 #include "game/graphlib.h"
 #include "game/gsound.h"
 #include "game/loadsave.h"
@@ -433,6 +434,10 @@ int do_options()
             case KEY_UNDERSCORE:
             case KEY_MINUS:
                 DecGamma();
+                break;
+            case KEY_UPPERCASE_G:
+            case KEY_LOWERCASE_G:
+                do_graphics_advanced();
                 break;
             }
         }


### PR DESCRIPTION
## Summary
- add graphics_advanced module for Vulkan settings
- expose new options in options menu (press `G`)
- load/save GPU index, filtering, vsync, FPS limit and validation flag
- allow changing FPS limit at runtime
- select GPU and present mode in Vulkan renderer

## Testing
- `cmake ..` *(fails: could not download adecode)*