### PR TITLE
Implement Vulkan capabilities detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -278,6 +278,7 @@ target_sources(${EXECUTABLE_NAME} PUBLIC
     "src/render/vulkan_debugger.cc"
     "src/render/vulkan_thread_manager.cc"
     "src/render/vulkan_texture_manager.cc"
+    "src/render/vulkan_capabilities.cc"
 )
 
 if(IOS)

--- a/src/render/vulkan_capabilities.cc
+++ b/src/render/vulkan_capabilities.cc
@@ -1,0 +1,20 @@
+#include "render/vulkan_capabilities.h"
+
+namespace fallout {
+
+bool VulkanCapabilities::init(VkPhysicalDevice physicalDevice)
+{
+    VkPhysicalDeviceFeatures features{};
+    vkGetPhysicalDeviceFeatures(physicalDevice, &features);
+    hasGeometryShader = features.geometryShader == VK_TRUE;
+    hasComputeShader = features.computeShader == VK_TRUE;
+
+    VkPhysicalDeviceProperties props{};
+    vkGetPhysicalDeviceProperties(physicalDevice, &props);
+    maxTextureSize = props.limits.maxImageDimension2D;
+    return true;
+}
+
+VulkanCapabilities gVulkanCaps;
+
+} // namespace fallout

--- a/src/render/vulkan_capabilities.h
+++ b/src/render/vulkan_capabilities.h
@@ -1,0 +1,21 @@
+#ifndef FALLOUT_RENDER_VULKAN_CAPABILITIES_H_
+#define FALLOUT_RENDER_VULKAN_CAPABILITIES_H_
+
+#include <vulkan/vulkan.h>
+
+namespace fallout {
+
+class VulkanCapabilities {
+public:
+    bool init(VkPhysicalDevice physicalDevice);
+
+    bool hasGeometryShader = false;
+    bool hasComputeShader = false;
+    uint32_t maxTextureSize = 0;
+};
+
+extern VulkanCapabilities gVulkanCaps;
+
+} // namespace fallout
+
+#endif /* FALLOUT_RENDER_VULKAN_CAPABILITIES_H_ */

--- a/src/render/vulkan_render.cc
+++ b/src/render/vulkan_render.cc
@@ -3,11 +3,13 @@
 #include "game/graphics_advanced.h"
 #include "render/vulkan_thread_manager.h"
 #include "render/vulkan_debugger.h"
+#include "render/vulkan_capabilities.h"
 
 #include <SDL_vulkan.h>
 #include <vulkan/vulkan.h>
 
 #include <vector>
+#include <algorithm>
 
 namespace fallout {
 
@@ -32,6 +34,11 @@ namespace {
     {
         gVulkan.internalExtent.width = gVulkan.swapchainExtent.width / 2;
         gVulkan.internalExtent.height = gVulkan.swapchainExtent.height / 2;
+
+        if (gVulkanCaps.maxTextureSize > 0) {
+            gVulkan.internalExtent.width = std::min(gVulkan.internalExtent.width, gVulkanCaps.maxTextureSize);
+            gVulkan.internalExtent.height = std::min(gVulkan.internalExtent.height, gVulkanCaps.maxTextureSize);
+        }
 
         VkImageCreateInfo imageInfo { VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO };
         imageInfo.imageType = VK_IMAGE_TYPE_2D;
@@ -382,6 +389,8 @@ bool vulkan_render_init(VideoOptions* options)
     if (gGraphicsAdvanced.gpuIndex < static_cast<int>(gpuCount))
         index = gGraphicsAdvanced.gpuIndex;
     gVulkan.physicalDevice = gpus[index];
+
+    gVulkanCaps.init(gVulkan.physicalDevice);
 
     uint32_t familyCount = 0;
     vkGetPhysicalDeviceQueueFamilyProperties(gVulkan.physicalDevice, &familyCount, nullptr);


### PR DESCRIPTION
## Summary
- add a new `VulkanCapabilities` helper that queries device features
- record capabilities during Vulkan renderer initialization
- constrain internal image size using detected limits
- build system now compiles the new files

## Testing
- `cmake -S . -B build` *(fails: could not find SDL2)*
- `cmake --build build` *(not run due to previous failure)*