### PR TITLE
Add placeholder test suite

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,8 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSIONS NO)
 
+enable_testing()
+
 option(ASAN "Enable address sanitizer" OFF)
 option(UBSAN "Enable undefined behaviour sanitizer" OFF)
 
@@ -372,6 +374,8 @@ target_include_directories(${EXECUTABLE_NAME} PRIVATE ${SDL2_INCLUDE_DIRS})
 
 find_package(Vulkan REQUIRED)
 target_link_libraries(${EXECUTABLE_NAME} Vulkan::Vulkan)
+
+add_subdirectory(tests)
 
 if(APPLE)
     if(IOS)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.13)
+
+add_executable(f1_tests
+    fps_limiter_test.cpp
+    vulkan_available_test.cpp
+)
+
+target_include_directories(f1_tests PRIVATE
+    ${SDL2_INCLUDE_DIRS}
+    ${CMAKE_SOURCE_DIR}/src
+)
+
+target_link_libraries(f1_tests
+    ${SDL2_LIBRARIES}
+    Vulkan::Vulkan
+)
+
+add_test(NAME f1_basic_tests COMMAND f1_tests)

--- a/tests/fps_limiter_test.cpp
+++ b/tests/fps_limiter_test.cpp
@@ -1,0 +1,24 @@
+#include "fps_limiter.h"
+#include "test_harness.h"
+#include <SDL.h>
+
+int main() {
+    if (SDL_Init(SDL_INIT_TIMER | SDL_INIT_VIDEO) != 0) {
+        std::cerr << "SDL init failed" << std::endl;
+        return 1;
+    }
+
+    int failed = 0;
+    failed += run_test("FpsLimiterDefault", [](){
+        fallout::FpsLimiter limiter;
+        limiter.mark();
+        SDL_Delay(10);
+        Uint32 before = SDL_GetTicks();
+        limiter.throttle();
+        Uint32 after = SDL_GetTicks();
+        EXPECT_TRUE(after - before >= 0);
+    });
+
+    SDL_Quit();
+    return failed;
+}

--- a/tests/scripts/benchmark_backend.sh
+++ b/tests/scripts/benchmark_backend.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Placeholder benchmark script
+BACKEND=${1:-SDL}
+export FALLOUT_RENDER_BACKEND=$BACKEND
+TIMEFILE=$(mktemp)
+{ time ../fallout-ce --version >/dev/null; } 2> $TIMEFILE
+cat $TIMEFILE
+rm $TIMEFILE

--- a/tests/scripts/stress_test.sh
+++ b/tests/scripts/stress_test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Placeholder stress test
+BACKEND=${1:-SDL}
+export FALLOUT_RENDER_BACKEND=$BACKEND
+# run for 5 loops opening and closing the engine
+for i in $(seq 1 5); do
+  echo "Run $i"
+  ../fallout-ce --version >/dev/null || exit 1
+  sleep 1
+done

--- a/tests/test_harness.h
+++ b/tests/test_harness.h
@@ -1,0 +1,21 @@
+#pragma once
+#include <iostream>
+#include <stdexcept>
+#include <functional>
+
+inline int run_test(const char* name, std::function<void()> test) {
+    try {
+        test();
+        std::cout << name << ": OK" << std::endl;
+        return 0;
+    } catch (const std::exception& e) {
+        std::cerr << name << ": FAIL - " << e.what() << std::endl;
+        return 1;
+    } catch (...) {
+        std::cerr << name << ": FAIL - unknown" << std::endl;
+        return 1;
+    }
+}
+
+#define EXPECT_TRUE(cond) do { if (!(cond)) throw std::runtime_error("Expectation failed: " #cond); } while(0)
+#define EXPECT_EQ(a,b) do { if (!((a) == (b))) throw std::runtime_error("Expectation failed: " #a " == " #b); } while(0)

--- a/tests/vulkan_available_test.cpp
+++ b/tests/vulkan_available_test.cpp
@@ -1,0 +1,14 @@
+#include "render/vulkan_render.h"
+#include "test_harness.h"
+#include <iostream>
+
+int main() {
+    int failed = 0;
+    failed += run_test("VulkanAvailable", [](){
+        bool available = fallout::vulkan_is_available();
+        std::cout << "vulkan_is_available=" << available << std::endl;
+        // Just ensure the call doesn't crash
+        EXPECT_TRUE(available || !available);
+    });
+    return failed;
+}


### PR DESCRIPTION
## Summary
- add a lightweight test harness
- include unit tests for `FpsLimiter` and Vulkan availability
- integrate tests in the build and provide benchmark and stress scripts

## Testing
- `cmake ..` *(fails: unable to download adecode)*
- `ctest --output-on-failure` *(fails: No tests were found)*