### PR TITLE
Add Windows build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,57 @@
+name: build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - synchronize
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  windows:
+    name: Windows x64
+    runs-on: windows-2019
+    strategy:
+      matrix:
+        build_type: [Release, Debug]
+    steps:
+      - name: Clone
+        uses: actions/checkout@v4
+
+      - name: Configure
+        run: |
+          cmake \
+            -B build \
+            -G "Visual Studio 16 2019" \
+            -A x64 \
+            # EOL
+
+      - name: Build
+        run: |
+          cmake \
+            --build build \
+            --config ${{ matrix.build_type }} \
+            # EOL
+
+      - name: Test
+        run: |
+          cd build
+          ctest -C ${{ matrix.build_type }} --output-on-failure
+
+      - name: Package
+        run: |
+          cd build/${{ matrix.build_type }}
+          7z a fallout-ce-${{ matrix.build_type }}.zip fallout-ce.exe
+
+      - name: Upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: fallout-ce-windows-x64-${{ matrix.build_type }}
+          path: build/${{ matrix.build_type }}/fallout-ce-${{ matrix.build_type }}.zip
+          retention-days: 7


### PR DESCRIPTION
## Summary
- build on Windows x64 for Debug and Release
- run ctest and package artifacts

## Testing
- `pre-commit` *(fails: repository has no hooks)*
