### PR TITLE
Add logical device creation

### DIFF
--- a/src/graphics/vulkan/VulkanDevice.h
+++ b/src/graphics/vulkan/VulkanDevice.h
@@ -21,6 +21,9 @@ class VulkanDevice {
 public:
     bool selectPhysicalDevice(VkInstance instance, VkSurfaceKHR surface);
     VkPhysicalDevice getPhysicalDevice() const { return physicalDevice_; }
+    bool createLogicalDevice(VkSurfaceKHR surface, VkDevice& device,
+        VkQueue& graphicsQueue,
+        uint32_t& graphicsQueueFamily);
 
 private:
     bool isDeviceSuitable(VkPhysicalDevice device, VkSurfaceKHR surface);

--- a/src/render/vulkan_render.cc
+++ b/src/render/vulkan_render.cc
@@ -264,8 +264,12 @@ bool vulkan_render_init(VideoOptions* options)
         return false; // No suitable GPU
     }
     gVulkan.physicalDevice = deviceSelector.getPhysicalDevice();
-
-    // ... (queue families, device creation as before) ...
+    if (!deviceSelector.createLogicalDevice(gVulkan.surface,
+            gVulkan.device,
+            gVulkan.graphicsQueue,
+            gVulkan.graphicsQueueFamily)) {
+        return false;
+    }
     // Ensure gVulkan.resourceAllocator_, gVulkan.resourceManager_, gVulkan.camera_ are initialized.
     // This is a conceptual placeholder for where game would set these up.
     if (!gVulkan.resourceAllocator_) { /* ... fatal error ... */


### PR DESCRIPTION
## Summary
- implement a `createLogicalDevice` helper in `VulkanDevice`
- call the helper when initializing Vulkan renderer

## Testing
- `cmake ..` *(fails: could not fetch adecode dependency)*

------
https://chatgpt.com/codex/tasks/task_b_6839f9e820e083269687dc081aa387f6