### PR TITLE
Add VMA vertex buffer helper

### DIFF
--- a/src/graphics/vulkan/MemoryAllocator.cpp
+++ b/src/graphics/vulkan/MemoryAllocator.cpp
@@ -5,10 +5,11 @@ VmaAllocator MemoryAllocator::s_alloc { VK_NULL_HANDLE };
 void MemoryAllocator::init(VkInstance i, VkPhysicalDevice p, VkDevice d, uint32_t qf)
 {
     // Placeholder initialization using VMA
-    VmaVulkanFunctions funcs {};
+    VmaVulkanFunctions funcs{};
     funcs.vkGetInstanceProcAddr = vkGetInstanceProcAddr;
     funcs.vkGetDeviceProcAddr = vkGetDeviceProcAddr;
-    VmaAllocatorCreateInfo info {};
+    VmaAllocatorCreateInfo info{};
+    info.vulkanApiVersion = VK_API_VERSION_1_0;
     info.instance = i;
     info.physicalDevice = p;
     info.device = d;
@@ -44,4 +45,19 @@ VmaAllocation MemoryAllocator::createImage(VkImageCreateInfo& imgInfo, VkImage& 
     VmaAllocation alloc = nullptr;
     vmaCreateImage(s_alloc, &imgInfo, &allocInfo, &image, &alloc, nullptr);
     return alloc;
+}
+
+VmaAllocation MemoryAllocator::createVertexBuffer(VkDeviceSize size, VkBuffer& buffer)
+{
+    VkBufferCreateInfo bufferInfo { VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO };
+    bufferInfo.size = size;
+    bufferInfo.usage = VK_BUFFER_USAGE_VERTEX_BUFFER_BIT;
+    bufferInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+
+    VmaAllocationCreateInfo allocInfo {};
+    allocInfo.usage = VMA_MEMORY_USAGE_CPU_TO_GPU;
+
+    VmaAllocation allocation;
+    vmaCreateBuffer(s_alloc, &bufferInfo, &allocInfo, &buffer, &allocation, nullptr);
+    return allocation;
 }

--- a/src/graphics/vulkan/MemoryAllocator.hpp
+++ b/src/graphics/vulkan/MemoryAllocator.hpp
@@ -11,6 +11,7 @@ public:
     // helpers
     static VmaAllocation createBuffer(VkBufferCreateInfo&, VkBuffer&, VmaMemoryUsage);
     static VmaAllocation createImage(VkImageCreateInfo&, VkImage&, VmaMemoryUsage);
+    static VmaAllocation createVertexBuffer(VkDeviceSize, VkBuffer&);
 
 private:
     static VmaAllocator s_alloc;

--- a/src/graphics/vulkan/SpriteBatch.cpp
+++ b/src/graphics/vulkan/SpriteBatch.cpp
@@ -23,7 +23,7 @@ bool SpriteBatch::init(VkDevice device, VkPhysicalDevice physicalDevice, uint32_
     VkBufferCreateInfo bufInfo{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
     bufInfo.size = sizeof(verts);
     bufInfo.usage = VK_BUFFER_USAGE_VERTEX_BUFFER_BIT;
-    m_vertexAlloc = MemoryAllocator::createBuffer(bufInfo, m_vertexBuffer, VMA_MEMORY_USAGE_CPU_TO_GPU);
+    m_vertexAlloc = MemoryAllocator::createVertexBuffer(sizeof(verts), m_vertexBuffer);
 
     bufInfo.size = 1024 * sizeof(Sprite);
     bufInfo.usage = VK_BUFFER_USAGE_VERTEX_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;


### PR DESCRIPTION
## Summary
- expose and implement MemoryAllocator::createVertexBuffer
- update initialization to set Vulkan API version
- use the new helper in SpriteBatch

## Testing
- `cmake ..` *(fails: Parse error expected newline)*

------
https://chatgpt.com/codex/tasks/task_b_6839fd494bf48326bc05a7ab2072a8fc