### PR TITLE
Ajout du guide de transition Vulkan

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,22 +1,24 @@
 cmake_minimum_required(VERSION 3.13)
 
-    set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
+set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
 
-        set(EXECUTABLE_NAME fallout - ce)
+set(EXECUTABLE_NAME fallout-ce)
 
-            if (APPLE) if (IOS)
-                set(CMAKE_OSX_DEPLOYMENT_TARGET "12" CACHE STRING "")
-                    set(CMAKE_OSX_ARCHITECTURES "arm64" CACHE STRING "") else()
-                        set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13" CACHE STRING "")
-                            set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64" CACHE STRING "")
-                                endif()
-                                    endif()
+if(APPLE)
+    if(IOS)
+        set(CMAKE_OSX_DEPLOYMENT_TARGET "12" CACHE STRING "")
+        set(CMAKE_OSX_ARCHITECTURES "arm64" CACHE STRING "")
+    else()
+        set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13" CACHE STRING "")
+        set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64" CACHE STRING "")
+    endif()
+endif()
 
-                                        project($ { EXECUTABLE_NAME })
+project(${EXECUTABLE_NAME})
 
-                                            set(CMAKE_CXX_STANDARD 17)
-                                                set(CMAKE_CXX_STANDARD_REQUIRED YES)
-                                                    set(CMAKE_CXX_EXTENSIONS NO)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED YES)
+set(CMAKE_CXX_EXTENSIONS NO)
 
                                                         enable_testing()
 
@@ -25,37 +27,37 @@ cmake_minimum_required(VERSION 3.13)
 
 #Compile GLSL shaders to SPIR - V
                                                                     find_program(GLSLANG_VALIDATOR glslangValidator)
-                                                                        set(SHADER_DIR $ { CMAKE_CURRENT_SOURCE_DIR } / shaders)
-                                                                            set(SHADER_OUT_DIR $ { CMAKE_CURRENT_BINARY_DIR } / shaders)
+                                                                        set(SHADER_DIR ${ CMAKE_CURRENT_SOURCE_DIR } / shaders)
+                                                                            set(SHADER_OUT_DIR ${ CMAKE_CURRENT_BINARY_DIR } / shaders)
                                                                                 file(GLOB SHADER_SRC "${SHADER_DIR}/*.vert"
                                                                                                      "${SHADER_DIR}/*.frag")
                                                                                     set(SPIRV_OUTPUTS)
-                                                                                        foreach (SHADER $ { SHADER_SRC })
-                                                                                            get_filename_component(FILE_NAME $ { SHADER } NAME)
-                                                                                                set(SPIRV $ { SHADER_OUT_DIR } / $ { FILE_NAME }.spv)
+                                                                                        foreach (SHADER ${ SHADER_SRC })
+                                                                                            get_filename_component(FILE_NAME ${ SHADER } NAME)
+                                                                                                set(SPIRV ${ SHADER_OUT_DIR } / ${ FILE_NAME }.spv)
                                                                                                     add_custom_command(
-                                                                                                        OUTPUT $ { SPIRV } COMMAND $ { CMAKE_COMMAND } - E make_directory $ { SHADER_OUT_DIR } COMMAND $ { GLSLANG_VALIDATOR } - V $ { SHADER } - o $ { SPIRV } DEPENDS $ { SHADER })
-                                                                                                        list(APPEND SPIRV_OUTPUTS $ { SPIRV })
+                                                                                                        OUTPUT ${ SPIRV } COMMAND ${ CMAKE_COMMAND } - E make_directory ${ SHADER_OUT_DIR } COMMAND ${ GLSLANG_VALIDATOR } - V ${ SHADER } - o ${ SPIRV } DEPENDS ${ SHADER })
+                                                                                                        list(APPEND SPIRV_OUTPUTS ${ SPIRV })
                                                                                                             endforeach()
-                                                                                                                add_custom_target(shaders ALL DEPENDS $ { SPIRV_OUTPUTS })
+                                                                                                                add_custom_target(shaders ALL DEPENDS ${ SPIRV_OUTPUTS })
 
                                                                                                                     if (ANDROID)
-                                                                                                                        add_library($ { EXECUTABLE_NAME } SHARED) else()
-                                                                                                                            add_executable($ { EXECUTABLE_NAME } WIN32 MACOSX_BUNDLE)
+                                                                                                                        add_library(${ EXECUTABLE_NAME } SHARED) else()
+                                                                                                                            add_executable(${ EXECUTABLE_NAME } WIN32 MACOSX_BUNDLE)
                                                                                                                                 endif()
 
                                                                                                                                     if (ASAN)
-                                                                                                                                        target_compile_options($ { EXECUTABLE_NAME } PUBLIC "-fsanitize=address;-fsanitize-recover=address")
-                                                                                                                                            target_link_options($ { EXECUTABLE_NAME } PUBLIC "-fsanitize=address;-fsanitize-recover=address")
+                                                                                                                                        target_compile_options(${ EXECUTABLE_NAME } PUBLIC "-fsanitize=address;-fsanitize-recover=address")
+                                                                                                                                            target_link_options(${ EXECUTABLE_NAME } PUBLIC "-fsanitize=address;-fsanitize-recover=address")
                                                                                                                                                 endif() if (UBSAN)
-                                                                                                                                                    target_compile_options($ { EXECUTABLE_NAME } PUBLIC "-fsanitize=undefined")
-                                                                                                                                                        target_link_options($ { EXECUTABLE_NAME } PUBLIC "-fsanitize=undefined")
+                                                                                                                                                    target_compile_options(${ EXECUTABLE_NAME } PUBLIC "-fsanitize=undefined")
+                                                                                                                                                        target_link_options(${ EXECUTABLE_NAME } PUBLIC "-fsanitize=undefined")
                                                                                                                                                             endif()
 
-target_include_directories($ { EXECUTABLE_NAME } PUBLIC src external / VMA / include external / tinygltf)
-                                                                                                                                                                    target_compile_definitions($ { EXECUTABLE_NAME } PUBLIC VMA_STATIC_VULKAN_FUNCTIONS = 0)
+target_include_directories(${ EXECUTABLE_NAME } PUBLIC src external / VMA / include external / tinygltf)
+                                                                                                                                                                    target_compile_definitions(${ EXECUTABLE_NAME } PUBLIC VMA_STATIC_VULKAN_FUNCTIONS = 0)
 
-                                                                                                                                                                        target_sources($ { EXECUTABLE_NAME } PUBLIC
+                                                                                                                                                                        target_sources(${ EXECUTABLE_NAME } PUBLIC
                                                                                                                                                                             "src/game/actions.cc"
                                                                                                                                                                             "src/game/actions.h"
                                                                                                                                                                             "src/game/amutex.cc"
@@ -275,7 +277,7 @@ target_include_directories($ { EXECUTABLE_NAME } PUBLIC src external / VMA / inc
                                                                                                                                                                             "src/movie_lib.cc"
                                                                                                                                                                             "src/movie_lib.h")
 
-                                                                                                                                                                            target_sources($ { EXECUTABLE_NAME } PUBLIC
+                                                                                                                                                                            target_sources(${ EXECUTABLE_NAME } PUBLIC
                                                                                                                                                                                 "src/audio_engine.cc"
                                                                                                                                                                                 "src/audio_engine.h"
                                                                                                                                                                                 "src/fps_limiter.cc"
@@ -311,16 +313,18 @@ target_include_directories($ { EXECUTABLE_NAME } PUBLIC src external / VMA / inc
                 "src/graphics/renderer_factory.h"
                 "src/graphics/renderer_factory.cpp"
                 "src/graphics/sdl_renderer.cpp"
+                "src/graphics/RenderObject.cpp"
+                "src/graphics/RenderObject.h"
                                                                                                                                                                                 "src/graphics/vulkan/VulkanSpritePipeline.h")
 
                                                                                                                                                                                 if (IOS)
-                                                                                                                                                                                    target_sources($ { EXECUTABLE_NAME } PUBLIC
+                                                                                                                                                                                    target_sources(${ EXECUTABLE_NAME } PUBLIC
                                                                                                                                                                                         "src/platform/ios/paths.h"
                                                                                                                                                                                         "src/platform/ios/paths.mm")
                                                                                                                                                                                         endif()
 
                                                                                                                                                                                             if (WIN32)
-                                                                                                                                                                                                target_compile_definitions($ { EXECUTABLE_NAME } PUBLIC
+                                                                                                                                                                                                target_compile_definitions(${ EXECUTABLE_NAME } PUBLIC
                                                                                                                                                                                                         _CRT_SECURE_NO_WARNINGS
                                                                                                                                                                                                             _CRT_NONSTDC_NO_WARNINGS
                                                                                                                                                                                                                 NOMINMAX
@@ -328,11 +332,11 @@ target_include_directories($ { EXECUTABLE_NAME } PUBLIC src external / VMA / inc
                                                                                                                                                                                                     endif()
 
                                                                                                                                                                                                         if (WIN32)
-                                                                                                                                                                                                            target_link_libraries($ { EXECUTABLE_NAME } winmm)
+                                                                                                                                                                                                            target_link_libraries(${ EXECUTABLE_NAME } winmm)
                                                                                                                                                                                                                 endif()
 
                                                                                                                                                                                                                     if (WIN32)
-                                                                                                                                                                                                                        target_sources($ { EXECUTABLE_NAME } PUBLIC
+                                                                                                                                                                                                                        target_sources(${ EXECUTABLE_NAME } PUBLIC
                                                                                                                                                                                                                             "os/windows/fallout-ce.ico"
                                                                                                                                                                                                                             "os/windows/fallout-ce.rc")
                                                                                                                                                                                                                             endif()
@@ -342,20 +346,20 @@ target_include_directories($ { EXECUTABLE_NAME } PUBLIC src external / VMA / inc
                                                                                                                                                                                                                                         "os/ios/AppIcon.xcassets"
                                                                                                                                                                                                                                         "os/ios/LaunchScreen.storyboard")
 
-                                                                                                                                                                                                                                        target_sources($ { EXECUTABLE_NAME } PUBLIC $ { RESOURCES })
-                                                                                                                                                                                                                                            set_source_files_properties($ { RESOURCES } PROPERTIES MACOSX_PACKAGE_LOCATION "Resources")
+                                                                                                                                                                                                                                        target_sources(${ EXECUTABLE_NAME } PUBLIC ${ RESOURCES })
+                                                                                                                                                                                                                                            set_source_files_properties(${ RESOURCES } PROPERTIES MACOSX_PACKAGE_LOCATION "Resources")
 
-                                                                                                                                                                                                                                                set_target_properties($ { EXECUTABLE_NAME } PROPERTIES MACOSX_BUNDLE_INFO_PLIST "${CMAKE_SOURCE_DIR}/os/ios/Info.plist" XCODE_ATTRIBUTE_ASSETCATALOG_COMPILER_APPICON_NAME "AppIcon" XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "com.alexbatalov.fallout-ce" XCODE_ATTRIBUTE_TARGETED_DEVICE_FAMILY "1,2")
+                                                                                                                                                                                                                                                set_target_properties(${ EXECUTABLE_NAME } PROPERTIES MACOSX_BUNDLE_INFO_PLIST "${CMAKE_SOURCE_DIR}/os/ios/Info.plist" XCODE_ATTRIBUTE_ASSETCATALOG_COMPILER_APPICON_NAME "AppIcon" XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "com.alexbatalov.fallout-ce" XCODE_ATTRIBUTE_TARGETED_DEVICE_FAMILY "1,2")
 
                                                                                                                                                                                                                                                     set(MACOSX_BUNDLE_BUNDLE_NAME "${EXECUTABLE_NAME}")
                                                                                                                                                                                                                                                         set(MACOSX_BUNDLE_DISPLAY_NAME "Fallout") else()
                                                                                                                                                                                                                                                             set(RESOURCES
                                                                                                                                                                                                                                                                 "os/macos/fallout-ce.icns")
 
-                                                                                                                                                                                                                                                                target_sources($ { EXECUTABLE_NAME } PUBLIC $ { RESOURCES })
-                                                                                                                                                                                                                                                                    set_source_files_properties($ { RESOURCES } PROPERTIES MACOSX_PACKAGE_LOCATION "Resources")
+                                                                                                                                                                                                                                                                target_sources(${ EXECUTABLE_NAME } PUBLIC ${ RESOURCES })
+                                                                                                                                                                                                                                                                    set_source_files_properties(${ RESOURCES } PROPERTIES MACOSX_PACKAGE_LOCATION "Resources")
 
-                                                                                                                                                                                                                                                                        set_target_properties($ { EXECUTABLE_NAME } PROPERTIES OUTPUT_NAME "Fallout Community Edition" MACOSX_BUNDLE_INFO_PLIST "${CMAKE_SOURCE_DIR}/os/macos/Info.plist" XCODE_ATTRIBUTE_EXECUTABLE_NAME "${EXECUTABLE_NAME}" XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "com.alexbatalov.fallout-ce")
+                                                                                                                                                                                                                                                                        set_target_properties(${ EXECUTABLE_NAME } PROPERTIES OUTPUT_NAME "Fallout Community Edition" MACOSX_BUNDLE_INFO_PLIST "${CMAKE_SOURCE_DIR}/os/macos/Info.plist" XCODE_ATTRIBUTE_EXECUTABLE_NAME "${EXECUTABLE_NAME}" XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "com.alexbatalov.fallout-ce")
 
                                                                                                                                                                                                                                                                             set(MACOSX_BUNDLE_ICON_FILE "fallout-ce.icns")
                                                                                                                                                                                                                                                                                 set(MACOSX_BUNDLE_BUNDLE_NAME "Fallout: Community Edition")
@@ -367,33 +371,33 @@ target_include_directories($ { EXECUTABLE_NAME } PUBLIC src external / VMA / inc
                                                                                                                                                                                                                                                                                                     set(MACOSX_BUNDLE_BUNDLE_VERSION "1.0.0")
                                                                                                                                                                                                                                                                                                         endif()
 
-                                                                                                                                                                                                                                                                                                            if ((NOT $ { CMAKE_SYSTEM_NAME } MATCHES "Linux")AND(NOT $ { CMAKE_SYSTEM_NAME } MATCHES "FreeBSD") AND(NOT $ { CMAKE_SYSTEM_NAME } MATCHES "OpenBSD"))
+                                                                                                                                                                                                                                                                                                            if ((NOT ${ CMAKE_SYSTEM_NAME } MATCHES "Linux")AND(NOT ${ CMAKE_SYSTEM_NAME } MATCHES "FreeBSD") AND(NOT ${ CMAKE_SYSTEM_NAME } MATCHES "OpenBSD"))
                                                                                                                                                                                                                                                                                                                 add_subdirectory("third_party/sdl2") else()
                                                                                                                                                                                                                                                                                                                     find_package(SDL2)
                                                                                                                                                                                                                                                                                                                         endif()
 
                                                                                                                                                                                                                                                                                                                             add_subdirectory("third_party/adecode")
-                                                                                                                                                                                                                                                                                                                                target_link_libraries($ { EXECUTABLE_NAME } adecode::adecode)
+                                                                                                                                                                                                                                                                                                                                target_link_libraries(${ EXECUTABLE_NAME } adecode::adecode)
 
                                                                                                                                                                                                                                                                                                                                     add_subdirectory("third_party/fpattern")
-                                                                                                                                                                                                                                                                                                                                        target_link_libraries($ { EXECUTABLE_NAME } fpattern::fpattern)
+                                                                                                                                                                                                                                                                                                                                        target_link_libraries(${ EXECUTABLE_NAME } fpattern::fpattern)
 
-                                                                                                                                                                                                                                                                                                                                            target_link_libraries($ { EXECUTABLE_NAME } $ { SDL2_LIBRARIES })
-                                                                                                                                                                                                                                                                                                                                                target_include_directories($ { EXECUTABLE_NAME } PRIVATE $ { SDL2_INCLUDE_DIRS })
+                                                                                                                                                                                                                                                                                                                                            target_link_libraries(${ EXECUTABLE_NAME } ${ SDL2_LIBRARIES })
+                                                                                                                                                                                                                                                                                                                                                target_include_directories(${ EXECUTABLE_NAME } PRIVATE ${ SDL2_INCLUDE_DIRS })
 
                                                                                                                                                                                                                                                                                                                                                     find_package(Vulkan REQUIRED)
-                                                                                                                                                                                                                                                                                                                                                        target_link_libraries($ { EXECUTABLE_NAME } Vulkan::Vulkan)
+                                                                                                                                                                                                                                                                                                                                                        target_link_libraries(${ EXECUTABLE_NAME } Vulkan::Vulkan)
 
                                                                                                                                                                                                                                                                                                                                                             add_subdirectory(tests)
 
                                                                                                                                                                                                                                                                                                                                                                 if (APPLE) if (IOS)
-                                                                                                                                                                                                                                                                                                                                                                    install(TARGETS $ { EXECUTABLE_NAME } DESTINATION "Payload")
+                                                                                                                                                                                                                                                                                                                                                                    install(TARGETS ${ EXECUTABLE_NAME } DESTINATION "Payload")
 
                                                                                                                                                                                                                                                                                                                                                                         set(CPACK_GENERATOR "ZIP")
                                                                                                                                                                                                                                                                                                                                                                             set(CPACK_INCLUDE_TOPLEVEL_DIRECTORY OFF)
                                                                                                                                                                                                                                                                                                                                                                                 set(CPACK_PACKAGE_FILE_NAME "fallout-ce")
                                                                                                                                                                                                                                                                                                                                                                                     set(CPACK_ARCHIVE_FILE_EXTENSION "ipa") else()
-                                                                                                                                                                                                                                                                                                                                                                                        install(TARGETS $ { EXECUTABLE_NAME } DESTINATION.)
+                                                                                                                                                                                                                                                                                                                                                                                        install(TARGETS ${ EXECUTABLE_NAME } DESTINATION.)
 
                                                                                                                                                                                                                                                                                                                                                                                             set(CPACK_GENERATOR "DragNDrop")
                                                                                                                                                                                                                                                                                                                                                                                                 set(CPACK_DMG_DISABLE_APPLICATIONS_SYMLINK ON)

--- a/TODO.md
+++ b/TODO.md
@@ -21,6 +21,8 @@
 - [x] Allocateur mémoire Vulkan avec pools pour vertex/index/uniformes.
 - [x] Fallback automatique vers les sprites en cas d'échec 3D.
 - [ ] Support de modèles glTF 2.0 (chargement, materials, animations).
+- [ ] Implémenter une transition intelligente Sprite/3D avec cache des sprites.
+- [ ] Mettre en place une interface de rendu unifiée (`RenderObject`).
 
 ### Intégration dans la boucle de jeu
 - [ ] Adaptation des entités (critter, objets) pour choisir entre sprite et modèle.

--- a/docs/vulkan_integration_guide.md
+++ b/docs/vulkan_integration_guide.md
@@ -75,3 +75,31 @@ VULKAN_GPU_INDEX=0
 The build integrates a lightweight copy of `tinygltf` located in `external/tinygltf`.
 No additional dependencies are required. Enable or disable glTF tests through the
 standard `f1_tests` target.
+
+### 2.2 Transition intelligente
+
+**Stratégie de fallback** :
+1. **Niveau 1** : 3D → Sprite Vulkan (garde les performances GPU)
+2. **Niveau 2** : Sprite Vulkan → Software (compatibility totale)
+
+**Cache des sprites** :
+- Pré-rendre les modèles 3D en sprites dans différentes orientations
+- Système de LOD basé sur la distance
+- Compression des textures pour économiser la VRAM
+
+### 2.3 Interface de rendu unifiée
+
+```c
+typedef struct RenderObject {
+    ObjectType type;
+    union {
+        ModelAsset* model;
+        SpriteData* sprite;
+    } data;
+    Transform transform;
+    MaterialID material;
+} RenderObject;
+
+// API unifiée
+void render_object(RenderObject* obj, RenderMode mode);
+```

--- a/src/graphics/RenderObject.cpp
+++ b/src/graphics/RenderObject.cpp
@@ -1,0 +1,22 @@
+#include "graphics/RenderObject.h"
+
+namespace fallout {
+namespace graphics {
+
+void render_object(RenderObject* obj, RenderMode mode)
+{
+    if (!obj)
+        return;
+
+    ObjectType effectiveType = obj->type;
+    if (mode == RenderMode::FORCE_SPRITE)
+        effectiveType = ObjectType::SPRITE;
+    else if (mode == RenderMode::FORCE_MODEL)
+        effectiveType = ObjectType::MODEL;
+
+    // TODO: integrate with SDL or Vulkan renderers
+    (void)effectiveType;
+}
+
+} // namespace graphics
+} // namespace fallout

--- a/src/graphics/RenderObject.h
+++ b/src/graphics/RenderObject.h
@@ -1,0 +1,47 @@
+#ifndef FALLOUT_GRAPHICS_RENDER_OBJECT_H_
+#define FALLOUT_GRAPHICS_RENDER_OBJECT_H_
+
+#include "graphics/SpriteTypes.h"
+#include "graphics/RenderableTypes.h"
+
+namespace fallout {
+namespace graphics {
+
+// Type of object to render
+enum class ObjectType {
+    SPRITE,
+    MODEL
+};
+
+// Mode forcing sprite or model rendering
+enum class RenderMode {
+    AUTOMATIC,
+    FORCE_SPRITE,
+    FORCE_MODEL
+};
+
+struct Transform {
+    Vec3 position{0, 0, 0};
+    Vec4 rotation{0, 0, 0, 1};
+    Vec3 scale{1, 1, 1};
+};
+
+using MaterialID = int;
+
+struct RenderObject {
+    ObjectType type = ObjectType::SPRITE;
+    union {
+        SpriteData* sprite;
+        ModelAsset* model;
+    } data{nullptr};
+    Transform transform{};
+    MaterialID material = 0;
+};
+
+// Unified rendering entry point (stub)
+void render_object(RenderObject* obj, RenderMode mode);
+
+} // namespace graphics
+} // namespace fallout
+
+#endif // FALLOUT_GRAPHICS_RENDER_OBJECT_H_


### PR DESCRIPTION
## Notes
- Ajout d'une structure `RenderObject` minimale et d'une fonction `render_object`.
- Extension du guide d'intégration Vulkan avec la transition intelligente et l'interface unifiée.
- Mise à jour du fichier TODO avec les nouvelles tâches.
- Correction du début du `CMakeLists.txt` pour qu'il s'analyse correctement (remplacement de la syntaxe corrompue).

## Testing
- `cmake ..` (échoue : `Parse error. Expected a newline, got identifier with text "else"`)


------
https://chatgpt.com/codex/tasks/task_b_683a052544a48326bb3d944cf74b99c6