### PR TITLE
Add Vulkan buffer pools

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -26,6 +26,7 @@
 - [ ] Mettre en place le `FallbackManager` pour détecter les échecs 3D.
 - [x] Gestionnaire de ressources hybride (sprites + modèles 3D) initial implémenté.
 - [x] Allocateur mémoire Vulkan avec pools pour vertex/index/uniformes.
+- [ ] Génération automatique des mipmaps pour les textures.
 - [x] Fallback automatique vers les sprites en cas d'échec 3D.
 - [ ] Support de modèles glTF 2.0 (chargement, materials, animations).
 - [ ] Implémenter une transition intelligente Sprite/3D avec cache des sprites.

--- a/docs/vulkan_integration_guide.md
+++ b/docs/vulkan_integration_guide.md
@@ -119,3 +119,8 @@ GLTF_MODEL_PATH=data/models/
 ANIMATION_QUALITY=HIGH
 PBR_SHADING=1
 3.3 Performance et debuggingMétriques à exposer :FPS et frame timeMémoire GPU utiliséeNombre de draw callsTaille des descriptor setsTemps de chargement glTFDebug features :Wireframe modeNormal visualizationTexture atlas viewerAnimation timeline scrubber
+
+Cette structure isole le code spécifique à Vulkan. L'allocation mémoire utilise
+désormais `VulkanResourceAllocator` avec des pools dédiés pour les buffers de
+vertex, d'index et d'uniformes afin de réduire la fragmentation et d'améliorer
+les performances.

--- a/src/graphics/vulkan/VulkanResourceAllocator.cpp
+++ b/src/graphics/vulkan/VulkanResourceAllocator.cpp
@@ -70,6 +70,29 @@ bool VulkanResourceAllocator::Init(VkInstance instance, VkPhysicalDevice physica
         return false;
     }
 
+    // Create dedicated pools for common buffer types
+    auto create_pool = [&](VkBufferUsageFlags usage, VmaMemoryUsage memUsage, VkDeviceSize blockSize, VmaPool& pool) {
+        VkBufferCreateInfo bInfo{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
+        bInfo.size = 256; // small size to query memory type
+        bInfo.usage = usage;
+        VmaAllocationCreateInfo aInfo{};
+        aInfo.usage = memUsage;
+        uint32_t typeIndex = 0;
+        if (vmaFindMemoryTypeIndexForBufferInfo(vmaAllocator_, &bInfo, &aInfo, &typeIndex) == VK_SUCCESS) {
+            VmaPoolCreateInfo pInfo{};
+            pInfo.memoryTypeIndex = typeIndex;
+            pInfo.blockSize = blockSize;
+            vmaCreatePool(vmaAllocator_, &pInfo, &pool);
+        }
+    };
+
+    create_pool(VK_BUFFER_USAGE_VERTEX_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
+                VMA_MEMORY_USAGE_GPU_ONLY, 16 * 1024 * 1024, vertexBufferPool_);
+    create_pool(VK_BUFFER_USAGE_INDEX_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
+                VMA_MEMORY_USAGE_GPU_ONLY, 16 * 1024 * 1024, indexBufferPool_);
+    create_pool(VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
+                VMA_MEMORY_USAGE_CPU_TO_GPU, 4 * 1024 * 1024, uniformBufferPool_);
+
     device_ = device;
     initialized_ = true;
     return true;
@@ -79,10 +102,19 @@ void VulkanResourceAllocator::Shutdown() {
     if (!initialized_) {
         return;
     }
+    if (vertexBufferPool_ != VK_NULL_HANDLE)
+        vmaDestroyPool(vmaAllocator_, vertexBufferPool_);
+    if (indexBufferPool_ != VK_NULL_HANDLE)
+        vmaDestroyPool(vmaAllocator_, indexBufferPool_);
+    if (uniformBufferPool_ != VK_NULL_HANDLE)
+        vmaDestroyPool(vmaAllocator_, uniformBufferPool_);
     if (vmaAllocator_ != VK_NULL_HANDLE) {
         vmaDestroyAllocator(vmaAllocator_);
         vmaAllocator_ = VK_NULL_HANDLE;
     }
+    vertexBufferPool_ = VK_NULL_HANDLE;
+    indexBufferPool_ = VK_NULL_HANDLE;
+    uniformBufferPool_ = VK_NULL_HANDLE;
     device_ = VK_NULL_HANDLE;
     initialized_ = false;
 }
@@ -129,11 +161,13 @@ bool VulkanResourceAllocator::CreateVertexBuffer(VkDeviceSize size, AllocatedBuf
     VmaAllocationCreateInfo allocInfo = {};
     if (deviceLocal) {
         allocInfo.usage = VMA_MEMORY_USAGE_GPU_ONLY;
+        allocInfo.pool = vertexBufferPool_;
     } else {
         allocInfo.usage = VMA_MEMORY_USAGE_CPU_TO_GPU; // For dynamic VBs updated by CPU
         if (mapped) {
             allocInfo.flags |= VMA_ALLOCATION_CREATE_MAPPED_BIT;
         }
+        allocInfo.pool = vertexBufferPool_;
     }
 
     bool success = CreateBuffer(bufferInfo, allocInfo, outBuffer);
@@ -158,11 +192,13 @@ bool VulkanResourceAllocator::CreateIndexBuffer(VkDeviceSize size, AllocatedBuff
     VmaAllocationCreateInfo allocInfo = {};
     if (deviceLocal) {
         allocInfo.usage = VMA_MEMORY_USAGE_GPU_ONLY;
+        allocInfo.pool = indexBufferPool_;
     } else {
         allocInfo.usage = VMA_MEMORY_USAGE_CPU_TO_GPU;
          if (mapped) {
             allocInfo.flags |= VMA_ALLOCATION_CREATE_MAPPED_BIT;
         }
+        allocInfo.pool = indexBufferPool_;
     }
 
     bool success = CreateBuffer(bufferInfo, allocInfo, outBuffer);
@@ -190,6 +226,7 @@ bool VulkanResourceAllocator::CreateUniformBuffer(VkDeviceSize size, AllocatedBu
         // and the pointer is available via VmaAllocationInfo.pMappedData or by calling vmaMapMemory
         allocInfo.flags |= VMA_ALLOCATION_CREATE_MAPPED_BIT;
     }
+    allocInfo.pool = uniformBufferPool_;
 
     bool success = CreateBuffer(bufferInfo, allocInfo, outBuffer);
     if (success && persistentlyMapped && !outBuffer.mappedData) {
@@ -341,7 +378,7 @@ bool VulkanResourceAllocator::CreateTextureImage(const char* filePath,
     imageInfo.extent.width = static_cast<uint32_t>(texWidth);
     imageInfo.extent.height = static_cast<uint32_t>(texHeight);
     imageInfo.extent.depth = 1;
-    imageInfo.mipLevels = 1; // TODO: Mipmap generation
+    imageInfo.mipLevels = 1; // TODO: implement mipmap generation
     imageInfo.arrayLayers = 1;
     imageInfo.format = VK_FORMAT_R8G8B8A8_UNORM; // Or SRGB if color space correct
     imageInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
@@ -428,10 +465,10 @@ bool VulkanResourceAllocator::CreateTextureImage(const char* filePath,
     samplerInfo.unnormalizedCoordinates = VK_FALSE;
     samplerInfo.compareEnable = VK_FALSE;
     samplerInfo.compareOp = VK_COMPARE_OP_ALWAYS;
-    samplerInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR; // TODO: Mipmap support
+    samplerInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR; // TODO: support mipmapped textures
     samplerInfo.mipLodBias = 0.0f;
     samplerInfo.minLod = 0.0f;
-    samplerInfo.maxLod = 0.0f; // TODO: Mipmap support (maxLod should be num_mips -1)
+    samplerInfo.maxLod = 0.0f; // TODO: set to num_mips - 1 when generating mipmaps
 
     if (vkCreateSampler(device_, &samplerInfo, nullptr, &outTextureSampler) != VK_SUCCESS) {
         // Log error

--- a/src/graphics/vulkan/VulkanResourceAllocator.h
+++ b/src/graphics/vulkan/VulkanResourceAllocator.h
@@ -78,6 +78,10 @@ private:
     VmaAllocator vmaAllocator_ = VK_NULL_HANDLE;
     VkDevice device_ = VK_NULL_HANDLE; // Store for destroying views, etc.
     bool initialized_ = false;
+    // Memory pools for specific buffer types
+    VmaPool vertexBufferPool_ = VK_NULL_HANDLE;
+    VmaPool indexBufferPool_ = VK_NULL_HANDLE;
+    VmaPool uniformBufferPool_ = VK_NULL_HANDLE;
 };
 
 } // namespace vk


### PR DESCRIPTION
## Summary
- create VMA pools for vertex, index and uniform buffers
- destroy pools on shutdown
- allocate from the pools when creating buffers
- clarify mipmap TODO comments and document mipmap generation in TODO list
- mention the pool-based allocator in Vulkan integration guide

## Testing
- `cmake -S . -B build` (fails: Parse error in CMakeLists.txt)
- `ctest --test-dir build` (no tests were found)

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_b_683a077b9d7483268ae1320adc47adb5