### PR TITLE
Integrate VMA memory manager

### DIFF
--- a/src/render/vulkan_memory_manager.h
+++ b/src/render/vulkan_memory_manager.h
@@ -1,58 +1,84 @@
-#ifndef FALLOUT_RENDER_VULKAN_MEMORY_MANAGER_H_
-#define FALLOUT_RENDER_VULKAN_MEMORY_MANAGER_H_
+#pragma once
 
-#include <vector>
+#include <memory>
+#include <vk_mem_alloc.h>
 #include <vulkan/vulkan.h>
 
 namespace fallout {
 
-class VulkanMemoryManager {
-public:
-    VulkanMemoryManager() = default;
-
-    bool init(VkPhysicalDevice physicalDevice, VkDevice device);
-    void destroy();
-
-    enum class PoolType {
-        Vertex,
-        Index,
-        Uniform,
-    };
-
-    struct Allocation {
-        VkBuffer buffer = VK_NULL_HANDLE;
-        VkDeviceMemory memory = VK_NULL_HANDLE;
-        VkDeviceSize offset = 0;
-    };
-
-    // Allocate a buffer from the given pool. Returns false on failure.
-    bool allocate_buffer(PoolType type, VkDeviceSize size, VkBufferUsageFlags usage, Allocation& out);
-
-    // Create a texture image using a temporary staging buffer.
-    bool create_texture_with_staging(const void* pixels, VkDeviceSize size,
-        const VkImageCreateInfo& imageInfo, VkCommandPool commandPool, VkQueue queue,
-        VkImage& image, VkDeviceMemory& memory);
-
-private:
-    struct MemoryPool {
-        VkDeviceMemory memory = VK_NULL_HANDLE;
-        VkDeviceSize size = 0;
-        VkDeviceSize offset = 0;
-    };
-
-    VkPhysicalDevice m_physicalDevice = VK_NULL_HANDLE;
-    VkDevice m_device = VK_NULL_HANDLE;
-
-    MemoryPool m_vertexPool {};
-    MemoryPool m_indexPool {};
-    MemoryPool m_uniformPool {};
-
-    uint32_t find_memory_type(uint32_t typeFilter, VkMemoryPropertyFlags properties);
-    bool init_pool(MemoryPool& pool, VkDeviceSize size, VkBufferUsageFlags usage, VkMemoryPropertyFlags properties);
-    bool create_buffer(VkDeviceSize size, VkBufferUsageFlags usage, VkMemoryPropertyFlags properties,
-        VkBuffer& buffer, VkDeviceMemory& memory);
+struct VulkanBuffer {
+    VkBuffer buffer = VK_NULL_HANDLE;
+    VmaAllocation allocation = VK_NULL_HANDLE;
+    VmaAllocationInfo allocInfo{};
+    VkDeviceSize size = 0;
+    void* mappedData = nullptr;
 };
 
-} // namespace fallout
+struct VulkanImage {
+    VkImage image = VK_NULL_HANDLE;
+    VkImageView imageView = VK_NULL_HANDLE;
+    VmaAllocation allocation = VK_NULL_HANDLE;
+    VkFormat format = VK_FORMAT_UNDEFINED;
+    VkExtent2D extent{};
+};
 
-#endif /* FALLOUT_RENDER_VULKAN_MEMORY_MANAGER_H_ */
+class VulkanMemoryManager {
+    VmaAllocator m_allocator = VK_NULL_HANDLE;
+    VkDevice m_device = VK_NULL_HANDLE;
+
+public:
+    bool init(VkInstance instance, VkPhysicalDevice physicalDevice, VkDevice device);
+    void destroy();
+
+    VmaAllocator getAllocator() const { return m_allocator; }
+    VkDevice getDevice() const { return m_device; }
+
+    VulkanBuffer createVertexBuffer(const void* data, VkDeviceSize size);
+    VulkanBuffer createUniformBuffer(VkDeviceSize size);
+    VulkanBuffer createStagingBuffer(VkDeviceSize size);
+
+    VulkanImage createSpriteAtlas(uint32_t width, uint32_t height, const void* data);
+    VulkanImage createPaletteTexture(const uint8_t* paletteData, uint32_t paletteCount);
+
+    void destroyBuffer(VulkanBuffer& buffer);
+    void destroyImage(VulkanImage& image);
+
+private:
+    void uploadDataToBuffer(VulkanBuffer& buffer, const void* data, VkDeviceSize size);
+    void uploadDataToImage(VulkanImage& image, const void* data, size_t sizeBytes);
+};
+
+class ManagedBuffer {
+    VulkanBuffer m_buffer{};
+    VmaAllocator m_allocator = VK_NULL_HANDLE;
+
+public:
+    ManagedBuffer(VmaAllocator alloc, const VulkanBuffer& buf) : m_buffer(buf), m_allocator(alloc) {}
+    ~ManagedBuffer();
+
+    VulkanBuffer* operator->() { return &m_buffer; }
+    const VulkanBuffer* operator->() const { return &m_buffer; }
+};
+
+class ManagedImage {
+    VulkanImage m_image{};
+    VmaAllocator m_allocator = VK_NULL_HANDLE;
+    VkDevice m_device = VK_NULL_HANDLE;
+
+public:
+    ManagedImage(VmaAllocator alloc, VkDevice dev, const VulkanImage& img)
+        : m_image(img)
+        , m_allocator(alloc)
+        , m_device(dev)
+    {
+    }
+    ~ManagedImage();
+
+    VulkanImage* operator->() { return &m_image; }
+    const VulkanImage* operator->() const { return &m_image; }
+};
+
+using BufferPtr = std::unique_ptr<ManagedBuffer>;
+using ImagePtr = std::unique_ptr<ManagedImage>;
+
+} // namespace fallout

--- a/src/render/vulkan_texture_manager.h
+++ b/src/render/vulkan_texture_manager.h
@@ -6,6 +6,7 @@
 #include <mutex>
 
 #include <vulkan/vulkan.h>
+#include <vk_mem_alloc.h>
 
 namespace fallout {
 
@@ -16,7 +17,7 @@ public:
     struct Texture {
         VkImage image = VK_NULL_HANDLE;
         VkImageView view = VK_NULL_HANDLE;
-        VkDeviceMemory memory = VK_NULL_HANDLE;
+        VmaAllocation memory = VK_NULL_HANDLE;
         VkExtent2D extent{};
         uint32_t mipLevels = 1;
     };


### PR DESCRIPTION
## Summary
- replace manual memory pools with a VMA-backed `VulkanMemoryManager`
- add RAII helpers for buffers and images
- update texture manager to use VMA allocations

## Testing
- `cmake ..` *(fails: Parse error in CMakeLists.txt)*

------
https://chatgpt.com/codex/tasks/task_b_683a149b7d08832688aef15cd9ca7233