### PR TITLE
Add FalloutMemoryManager header

### DIFF
--- a/src/graphics/fallout_animation_system.hpp
+++ b/src/graphics/fallout_animation_system.hpp
@@ -1,15 +1,13 @@
 #pragma once
 
 #include "graphics/diablo_animation_system.hpp"
-#include "render/vulkan_memory_manager.h"
+#include "render/fallout_memory_manager.h"
 #include <unordered_map>
 #include <memory>
 #include <string>
 
 namespace fallout {
 
-class FalloutMemoryManager : public VulkanMemoryManager {
-};
 
 class FalloutAssetManager {
 public:

--- a/src/graphics/hybrid_asset_manager.hpp
+++ b/src/graphics/hybrid_asset_manager.hpp
@@ -9,12 +9,8 @@
 #include <unordered_map>
 #include <memory>
 #include <optional>
+#include "render/fallout_memory_manager.h"
 namespace fallout {
-
-// Forward declarations
-class FalloutMemoryManager;
-struct AllocatedBuffer;
-struct AllocatedImage;
 
 /*** Legacy Fallout Asset Support ***/
 #pragma pack(push, 1)

--- a/src/render/fallout_memory_manager.h
+++ b/src/render/fallout_memory_manager.h
@@ -1,0 +1,117 @@
+#pragma once
+#include <vma/vk_mem_alloc.h>
+#include <vulkan/vulkan.h>
+#include <unordered_map>
+#include <vector>
+#include <memory>
+#include <string>
+#include <fstream>
+
+namespace fallout {
+
+struct AllocatedBuffer {
+    VkBuffer buffer = VK_NULL_HANDLE;
+    VmaAllocation allocation = VK_NULL_HANDLE;
+    VmaAllocationInfo info = {};
+    VkDeviceSize size = 0;
+    VkBufferUsageFlags usage = 0;
+    void* mapped = nullptr;
+    std::string debugName;
+    uint64_t allocationId = 0;
+};
+
+struct AllocatedImage {
+    VkImage image = VK_NULL_HANDLE;
+    VmaAllocation allocation = VK_NULL_HANDLE;
+    VmaAllocationInfo info = {};
+    VkImageView view = VK_NULL_HANDLE;
+    VkFormat format = VK_FORMAT_UNDEFINED;
+    VkExtent3D extent = {};
+    uint32_t mipLevels = 1;
+    uint32_t arrayLayers = 1;
+    VkImageUsageFlags usage = 0;
+    std::string debugName;
+    uint64_t allocationId = 0;
+};
+
+enum class MemoryUsagePattern {
+    STATIC_GEOMETRY,
+    DYNAMIC_UNIFORM,
+    STAGING_UPLOAD,
+    GPU_ONLY_TEXTURES,
+    READBACK_BUFFER,
+    PERSISTENT_MAPPED
+};
+
+struct MemoryPoolStats {
+    VkDeviceSize totalAllocated = 0;
+    VkDeviceSize totalUsed = 0;
+    uint32_t allocationCount = 0;
+    VkDeviceSize largestFreeBlock = 0;
+    float fragmentationRatio = 0.0f;
+};
+
+class FalloutMemoryManager {
+private:
+    VmaAllocator allocator = VK_NULL_HANDLE;
+    VkDevice device = VK_NULL_HANDLE;
+    std::unordered_map<MemoryUsagePattern, VmaPool> memoryPools;
+    uint64_t nextAllocationId = 1;
+    std::unordered_map<uint64_t, AllocatedBuffer> bufferAllocations;
+    std::unordered_map<uint64_t, AllocatedImage> imageAllocations;
+    mutable MemoryPoolStats globalStats;
+    mutable std::unordered_map<MemoryUsagePattern, MemoryPoolStats> poolStats;
+
+    struct StagingBuffer {
+        AllocatedBuffer buffer;
+        VkDeviceSize offset = 0;
+        bool inUse = false;
+    };
+    std::vector<StagingBuffer> stagingBuffers;
+    VkDeviceSize stagingBufferSize = 64 * 1024 * 1024;
+
+public:
+    bool initialize(VkInstance instance, VkPhysicalDevice physicalDevice, VkDevice dev);
+    uint64_t createBuffer(VkDeviceSize size, VkBufferUsageFlags usage, MemoryUsagePattern pattern, const std::string& debugName = "");
+    uint64_t createImage(VkExtent3D extent, VkFormat format, VkImageUsageFlags usage,
+                        uint32_t mipLevels = 1, uint32_t arrayLayers = 1,
+                        VkSampleCountFlagBits samples = VK_SAMPLE_COUNT_1_BIT,
+                        MemoryUsagePattern pattern = MemoryUsagePattern::GPU_ONLY_TEXTURES,
+                        const std::string& debugName = "");
+    bool uploadBufferData(uint64_t bufferId, const void* data, VkDeviceSize size, VkDeviceSize offset = 0);
+    MemoryPoolStats getGlobalStats() const;
+    MemoryPoolStats getPoolStats(MemoryUsagePattern pattern) const;
+    void generateMemoryReport(const std::string& filename) const;
+    AllocatedBuffer* getBuffer(uint64_t id);
+    AllocatedImage* getImage(uint64_t id);
+    void destroyBuffer(uint64_t id);
+    void destroyImage(uint64_t id);
+    void shutdown();
+
+private:
+    bool createMemoryPools();
+    bool createMemoryPool(MemoryUsagePattern pattern, VmaMemoryUsage usage, VkDeviceSize size);
+    VmaMemoryUsage getVmaUsage(MemoryUsagePattern pattern);
+    VmaAllocationCreateFlags getVmaFlags(MemoryUsagePattern pattern);
+    VmaPool getMemoryPool(MemoryUsagePattern pattern);
+    bool shouldAutoMap(MemoryUsagePattern pattern);
+    uint32_t findMemoryType(VmaMemoryUsage usage);
+    bool createStagingBuffers();
+    bool uploadViaStagingBuffer(VkBuffer dstBuffer, const void* data, VkDeviceSize size, VkDeviceSize offset);
+    VkImageAspectFlags getImageAspectMask(VkFormat format);
+    void setBufferDebugName(VkBuffer buffer, const std::string& name);
+    void setImageDebugName(VkImage image, const std::string& name);
+    void setImageViewDebugName(VkImageView view, const std::string& name);
+    void updateGlobalStats() const;
+    void updatePoolStats() const;
+    std::string memoryPatternToString(MemoryUsagePattern pattern) const;
+    std::string formatBytes(VkDeviceSize bytes) const;
+    std::string getCurrentTimeString() const;
+    static void debugAllocationCallback(VmaAllocator allocator, uint32_t memoryType,
+                                       VkDeviceMemory memory, VkDeviceSize size, void* pUserData);
+    static void debugFreeCallback(VmaAllocator allocator, uint32_t memoryType,
+                                 VkDeviceMemory memory, VkDeviceSize size, void* pUserData);
+};
+
+} // namespace fallout
+

--- a/src/render/fallout_post_processing.cpp
+++ b/src/render/fallout_post_processing.cpp
@@ -2,7 +2,7 @@
 
 namespace fallout {
 
-bool FalloutPostProcessing::initializeForFallout(VulkanMemoryManager* memMgr,
+bool FalloutPostProcessing::initializeForFallout(FalloutMemoryManager* memMgr,
                                                  VkDevice device,
                                                  VkAllocationCallbacks* alloc,
                                                  VkRenderPass renderPass,

--- a/src/render/fallout_post_processing.h
+++ b/src/render/fallout_post_processing.h
@@ -1,13 +1,13 @@
 #pragma once
 #include "render/diablo_post_processing.h"
-#include "render/vulkan_memory_manager.h"
+#include "render/fallout_memory_manager.h"
 
 namespace fallout {
 
 // Extension of DiabloPostProcessing for Fallout-specific presets
 class FalloutPostProcessing : public DiabloPostProcessing {
 private:
-    VulkanMemoryManager* memoryManager = nullptr;
+    FalloutMemoryManager* memoryManager = nullptr;
     // Presets tailored for the Fallout world
     DiabloPostFXSettings wastelandPreset{};
     DiabloPostFXSettings vaultPreset{};
@@ -18,7 +18,7 @@ private:
 
 public:
     // Initialize the post-processing system using Fallout's memory manager
-    bool initializeForFallout(VulkanMemoryManager* memMgr,
+    bool initializeForFallout(FalloutMemoryManager* memMgr,
                               VkDevice device,
                               VkAllocationCallbacks* alloc,
                               VkRenderPass renderPass,

--- a/src/render/vulkan_texture_manager.cc
+++ b/src/render/vulkan_texture_manager.cc
@@ -1,5 +1,5 @@
 #include "render/vulkan_texture_manager.h"
-#include "render/vulkan_memory_manager.h"
+#include "render/fallout_memory_manager.h"
 #include "render/vulkan_thread_manager.h"
 #include <cmath>
 
@@ -10,7 +10,7 @@
 namespace fallout {
 
 bool VulkanTextureManager::init(VkPhysicalDevice physicalDevice, VkDevice device,
-    VulkanMemoryManager* memoryManager, VkCommandPool commandPool, VkQueue queue)
+    FalloutMemoryManager* memoryManager, VkCommandPool commandPool, VkQueue queue)
 {
     m_physicalDevice = physicalDevice;
     m_device = device;

--- a/src/render/vulkan_texture_manager.h
+++ b/src/render/vulkan_texture_manager.h
@@ -7,10 +7,10 @@
 
 #include <vulkan/vulkan.h>
 #include <vk_mem_alloc.h>
+#include "render/fallout_memory_manager.h"
 
 namespace fallout {
 
-class VulkanMemoryManager;
 
 class VulkanTextureManager {
 public:
@@ -25,7 +25,7 @@ public:
     VulkanTextureManager() = default;
 
     bool init(VkPhysicalDevice physicalDevice, VkDevice device,
-        VulkanMemoryManager* memoryManager, VkCommandPool commandPool, VkQueue queue);
+        FalloutMemoryManager* memoryManager, VkCommandPool commandPool, VkQueue queue);
     void destroy();
 
     void loadTextureAsync(const std::string& path);
@@ -38,7 +38,7 @@ private:
 
     VkPhysicalDevice m_physicalDevice = VK_NULL_HANDLE;
     VkDevice m_device = VK_NULL_HANDLE;
-    VulkanMemoryManager* m_memoryManager = nullptr;
+    FalloutMemoryManager* m_memoryManager = nullptr;
     VkCommandPool m_commandPool = VK_NULL_HANDLE;
     VkQueue m_queue = VK_NULL_HANDLE;
 


### PR DESCRIPTION
## Summary
- introduce `FalloutMemoryManager` header with pooled VMA API
- reference the new memory manager in hybrid asset and animation systems
- update Fallout post-processing and texture manager to use it

## Testing
- `cmake -B build` *(fails: Parse error)*

------
https://chatgpt.com/codex/tasks/task_b_683aaf2dc5a883268b60cd0cefdca330